### PR TITLE
Fix composer.json: use valid SPDX license and remove version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.3.0 - Not released
 ### Bug Fixes
 - Fixed `Task::setProgress()` with non-numeric values on PHP 8+ - @slayerfx GH-25
+- Fixed invalid SPDX license identifier in `composer.json` - @slayerfx GH-26
+- Removed unnecessary `version` field from `composer.json` - @slayerfx GH-26
 
 ### Miscellaneous
 - Deleted Travis files - @slayerfx GH-25

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "keywords": ["PHP","Project","GanttProject","gan","mpx"],
     "homepage": "http://phpoffice.github.io",
     "type": "library",
-    "license": "LGPL",
-    "version": "0.2.0",
+    "license": "LGPL-3.0-only",    
     "authors": [
         {
             "name": "Mark Baker"


### PR DESCRIPTION
- Fix invalid SPDX license identifier: `LGPL` → `LGPL-3.0-only`
- Remove unnecessary `version` field from `composer.json`


