### PR TITLE
Add code coverage configuration in phpunit.xml.dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `Task::setProgress()` with non-numeric values on PHP 8+ - @slayerfx GH-25
 - Fixed invalid SPDX license identifier in `composer.json` - @slayerfx GH-26
 - Removed unnecessary `version` field from `composer.json` - @slayerfx GH-26
+- Added code coverage configuration in `phpunit.xml.dist` - @slayerfx GH-27
 
 ### Miscellaneous
 - Deleted Travis files - @slayerfx GH-25

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,11 @@
          processIsolation="false"
          stopOnFailure="false"
          >
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="PhpProject Test Suite">
             <directory>./tests/PhpProject</directory>


### PR DESCRIPTION
- Add `<coverage>` block in `phpunit.xml.dist` to fix code coverage generation
- Without this configuration, PHPUnit skips coverage and `build/clover.xml` is not generated, causing the Coveralls upload to fail


