### PR TITLE
Add PHP 7.4-8.5 to CI matrix and fix null deprecation

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.3"]
+        php: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 - Fixed invalid SPDX license identifier in `composer.json` - @slayerfx GH-26
 - Removed unnecessary `version` field from `composer.json` - @slayerfx GH-26
 - Added code coverage configuration in `phpunit.xml.dist` - @slayerfx GH-27
+- Fixed `number_format()` null parameter deprecation in `MsProjectMPX` on PHP 8.1+ - @slayerfx GH-28
 
 ### Miscellaneous
+- Added PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 and 8.5 to CI matrix - @slayerfx GH-28
 - Deleted Travis files - @slayerfx GH-25
 - Migrated from Travis to GitHub Actions - @slayerfx GH-25
 - Dropped support for PHP 5.x/7.x, minimum PHP version is now 7.3 - @slayerfx GH-25

--- a/src/PhpProject/Writer/MsProjectMPX.php
+++ b/src/PhpProject/Writer/MsProjectMPX.php
@@ -243,7 +243,7 @@ class MsProjectMPX
      */
     private function writeRecord70(Task $oTask)
     {
-        $this->fileContent[] = '70;'.$oTask->getIndex().';'.$oTask->getName().';'.$oTask->getDuration().'d;'.number_format($oTask->getProgress(), 1).';'.date('d/m/Y', $oTask->getStartDate());
+        $this->fileContent[] = '70;'.$oTask->getIndex().';'.$oTask->getName().';'.$oTask->getDuration().'d;'.number_format($oTask->getProgress() ?? 0, 1).';'.date('d/m/Y', $oTask->getStartDate());
         
         foreach ($oTask->getResources() as $oResource) {
             $this->writeRecord75($oResource);


### PR DESCRIPTION
- Add PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 to CI matrix
- Fix `number_format()` null deprecation in MsProjectMPX.php
