### PR TITLE
Add phpstan job to CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -100,3 +100,25 @@ jobs:
 
       -   name: Generate samples files
           run: composer run samples
+
+  phpstan:
+    name: PHP Static Analysis
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+    steps:
+      -   name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: ${{ matrix.php }}
+              extensions: xml, zip
+
+      -   uses: actions/checkout@v2
+
+      -   name: Composer Install
+          run: composer install --ansi --prefer-dist --no-interaction --no-progress
+
+      -   name: Run phpstan
+          run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `number_format()` null parameter deprecation in `MsProjectMPX` on PHP 8.1+ - @slayerfx GH-28
 - Fixed `PhpProject` class casing in samples (was working on Windows only, broken on Linux) - @slayerfx GH-29
 - Fixed inaccurate `@return string` PHPDoc on `DocumentProperties::getCustomPropertyValue/Type()` (now `string|null`) - @slayerfx GH-31
+- Fixed PHP 8.4 implicit nullable parameter deprecations (now using `?Type $param = null`) - @slayerfx GH-31
 
 ### Miscellaneous
 - Added phpstan job to CI (level 1) - @slayerfx GH-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
 - Added code coverage configuration in `phpunit.xml.dist` - @slayerfx GH-27
 - Fixed `number_format()` null parameter deprecation in `MsProjectMPX` on PHP 8.1+ - @slayerfx GH-28
 - Fixed `PhpProject` class casing in samples (was working on Windows only, broken on Linux) - @slayerfx GH-29
+- Fixed inaccurate `@return string` PHPDoc on `DocumentProperties::getCustomPropertyValue/Type()` (now `string|null`) - @slayerfx GH-31
 
 ### Miscellaneous
+- Added phpstan job to CI (level 1) - @slayerfx GH-31
 - Replaced Scrutinizer code coverage badge with Coveralls in README - @slayerfx GH-30
 - Removed Scrutinizer Code Quality badge from README - @slayerfx GH-30
 - Added CI job to check samples execution - @slayerfx GH-29

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,9 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",        
+        "phpunit/phpunit": "^9.0",
         "phpmd/phpmd": "^2.15",
+        "phpstan/phpstan": "^1.10",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  level: 1
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -418,7 +418,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyValue(string $propertyName): ?string
+    public function getCustomPropertyValue($propertyName)
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['value'];
@@ -432,7 +432,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyType(string $propertyName): ?string
+    public function getCustomPropertyType($propertyName)
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['type'];

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -416,7 +416,7 @@ class DocumentProperties
      * Get a Custom Property Value
      *
      * @param    string    $propertyName
-     * @return    string
+     * @return    string|null
      */
     public function getCustomPropertyValue($propertyName)
     {
@@ -430,7 +430,7 @@ class DocumentProperties
      * Get a Custom Property Type
      *
      * @param    string    $propertyName
-     * @return    string
+     * @return    string|null
      */
     public function getCustomPropertyType($propertyName)
     {

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -418,7 +418,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyValue($propertyName)
+    public function getCustomPropertyValue(string $propertyName): ?string
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['value'];
@@ -432,7 +432,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyType($propertyName)
+    public function getCustomPropertyType(string $propertyName): ?string
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['type'];

--- a/src/PhpProject/IOFactory.php
+++ b/src/PhpProject/IOFactory.php
@@ -84,7 +84,7 @@ class IOFactory
      * @throws \Exception
      * @return
      */
-    private static function loadClass($class, $name, $type, PhpProject $phpProject = null)
+    private static function loadClass($class, $name, $type, ?PhpProject $phpProject = null)
     {
         if (class_exists($class) && self::isConcreteClass($class)) {
             if (is_null($phpProject)) {

--- a/src/PhpProject/PhpProject.php
+++ b/src/PhpProject/PhpProject.php
@@ -231,7 +231,7 @@ class PhpProject
      *
      * @return Task|null
      */
-    public function getTaskFromIndex($pIndex, Task $oTaskParent = null)
+    public function getTaskFromIndex($pIndex, ?Task $oTaskParent = null)
     {
         if (is_null($oTaskParent)) {
             $arrayTask = $this->taskCollection;

--- a/src/PhpProject/Shared/XMLReader.php
+++ b/src/PhpProject/Shared/XMLReader.php
@@ -85,7 +85,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return \DOMNodeList
      */
-    public function getElements($path, \DOMElement $contextNode = null)
+    public function getElements($path, ?\DOMElement $contextNode = null)
     {
         if ($this->dom === null) {
             return array();
@@ -104,7 +104,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return \DOMElement|null
      */
-    public function getElement($path, \DOMElement $contextNode = null)
+    public function getElement($path, ?\DOMElement $contextNode = null)
     {
         $elements = $this->getElements($path, $contextNode);
         if ($elements->length > 0) {
@@ -122,7 +122,7 @@ class XMLReader
      * @param string $path
      * @return string|null
      */
-    public function getAttribute($attribute, \DOMElement $contextNode = null, $path = null)
+    public function getAttribute($attribute, ?\DOMElement $contextNode = null, $path = null)
     {
         $return = null;
         if ($path !== null) {
@@ -148,7 +148,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return string|null
      */
-    public function getValue($path, \DOMElement $contextNode = null)
+    public function getValue($path, ?\DOMElement $contextNode = null)
     {
         $elements = $this->getElements($path, $contextNode);
         if ($elements->length > 0) {
@@ -165,7 +165,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return integer
      */
-    public function countElements($path, \DOMElement $contextNode = null)
+    public function countElements($path, ?\DOMElement $contextNode = null)
     {
         $elements = $this->getElements($path, $contextNode);
 
@@ -179,7 +179,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return boolean
      */
-    public function elementExists($path, \DOMElement $contextNode = null)
+    public function elementExists($path, ?\DOMElement $contextNode = null)
     {
         return $this->getElements($path, $contextNode)->length > 0;
     }


### PR DESCRIPTION
- Add `phpstan/phpstan ^1.10` as dev dependency
- Add `phpstan.neon.dist` with level 1 configuration
- Add `phpstan` job to GitHub Actions workflow (matrix PHP 7.3 → 8.5)
- Fix inaccurate `@return string` PHPDoc on `DocumentProperties::getCustomPropertyValue/Type()` (now `string|null`, revealed by phpstan locally)
- Fix PHP 8.4 implicit nullable parameter deprecations in `XMLReader`, `PhpProject` and `IOFactory` (now using `?Type $param = null`, revealed by phpstan in CI on PHP 8.4+)
