### PR TITLE
Bump phpstan analysis level from 1 to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,17 @@
 - Fixed `PhpProject` class casing in samples (was working on Windows only, broken on Linux) - @slayerfx GH-29
 - Fixed inaccurate `@return string` PHPDoc on `DocumentProperties::getCustomPropertyValue/Type()` (now `string|null`) - @slayerfx GH-31
 - Fixed PHP 8.4 implicit nullable parameter deprecations (now using `?Type $param = null`) - @slayerfx GH-31
+- Fixed `PhpProject::setInformations()` PHPDoc parameter type (was `PHPProject_DocumentProperties`, now `DocumentInformations`) - @slayerfx GH-32
+- Fixed `Task::setStartDate()/setEndDate()` PHPDoc return type (was `DocumentInformations`, now `self`) - @slayerfx GH-32
+- Fixed string/int operation in `Writer/GanttProject` and `Writer/MsProjectMPX::sanitizeTask` (explicit `(int)` cast on duration) - @slayerfx GH-32
+- Added explicit `return null;` in `DocumentProperties::getCustomPropertyValue/Type()` - @slayerfx GH-32
 
 ### Miscellaneous
+- Bumped phpstan analysis level from 1 to 2 - @slayerfx GH-32
+- Created `Reader/ReaderInterface` and `Writer/WriterInterface`, implemented in concrete Reader/Writer classes - @slayerfx GH-32
+- Updated obsolete PHPDoc class references (`PHPProject_*` → `self` or correct class name) - @slayerfx GH-32
+- Replaced invalid PHPDoc types (`datetime` → `int`, `index` → `int`, `multitype` → `array`, `Exception` → `\Exception`) - @slayerfx GH-32
+- Removed phantom `@param XMLReader $oXML` PHPDoc tags in `Reader/GanttProject` - @slayerfx GH-32
 - Added phpstan job to CI (level 1) - @slayerfx GH-31
 - Replaced Scrutinizer code coverage badge with Coveralls in README - @slayerfx GH-30
 - Removed Scrutinizer Code Quality badge from README - @slayerfx GH-30

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 1
+  level: 2
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -143,7 +143,7 @@ class DocumentProperties
      * Set Creator
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setCreator($pValue = '')
     {
@@ -165,7 +165,7 @@ class DocumentProperties
      * Set Last Modified By
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setLastModifiedBy($pValue = '')
     {
@@ -187,7 +187,7 @@ class DocumentProperties
      * Set Created
      *
      * @param    int    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setCreated($pValue = null)
     {
@@ -219,7 +219,7 @@ class DocumentProperties
      * Set Modified
      *
      * @param    int    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setModified($pValue = null)
     {
@@ -251,7 +251,7 @@ class DocumentProperties
      * Set Title
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setTitle($pValue = '')
     {
@@ -273,7 +273,7 @@ class DocumentProperties
      * Set Description
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setDescription($pValue = '')
     {
@@ -295,7 +295,7 @@ class DocumentProperties
      * Set Subject
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setSubject($pValue = '')
     {
@@ -317,7 +317,7 @@ class DocumentProperties
      * Set Keywords
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setKeywords($pValue = '')
     {
@@ -339,7 +339,7 @@ class DocumentProperties
      * Set Category
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setCategory($pValue = '')
     {
@@ -361,7 +361,7 @@ class DocumentProperties
      * Set Company
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setCompany($pValue = '')
     {
@@ -383,7 +383,7 @@ class DocumentProperties
      * Set Manager
      *
      * @param    string    $pValue
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setManager($pValue = '')
     {
@@ -423,7 +423,7 @@ class DocumentProperties
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['value'];
         }
-
+        return null;
     }
 
     /**
@@ -437,7 +437,7 @@ class DocumentProperties
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['type'];
         }
-
+        return null;
     }
 
     /**
@@ -451,7 +451,7 @@ class DocumentProperties
      *                        's': String
      *                        'd': Date/Time
      *                        'b': Boolean
-     * @return    PHPProject_DocumentProperties
+     * @return    self
      */
     public function setCustomProperty($propertyName, $propertyValue = '', $propertyType = null)
     {

--- a/src/PhpProject/IOFactory.php
+++ b/src/PhpProject/IOFactory.php
@@ -82,7 +82,7 @@ class IOFactory
      * @param string $type
      * @param \PhpOffice\PhpProject\PhpProject $phpProject
      * @throws \Exception
-     * @return
+     * @return \PhpOffice\PhpProject\Reader\ReaderInterface|\PhpOffice\PhpProject\Writer\WriterInterface
      */
     private static function loadClass($class, $name, $type, ?PhpProject $phpProject = null)
     {

--- a/src/PhpProject/PhpProject.php
+++ b/src/PhpProject/PhpProject.php
@@ -71,7 +71,7 @@ class PhpProject
     /**
      * Get properties
      *
-     * @return PHPProject_DocumentProperties
+     * @return DocumentProperties
      */
     public function getProperties()
     {
@@ -81,7 +81,7 @@ class PhpProject
     /**
      * Set properties
      *
-     * @param PHPProject_DocumentProperties    $pValue
+     * @param DocumentProperties $pValue
      */
     public function setProperties(DocumentProperties $pValue)
     {
@@ -105,7 +105,7 @@ class PhpProject
     /**
      * Set informations
      *
-     * @param PHPProject_DocumentProperties    $pValue
+     * @param DocumentInformations $pValue
      */
     public function setInformations(DocumentInformations $pValue)
     {

--- a/src/PhpProject/Reader/GanttProject.php
+++ b/src/PhpProject/Reader/GanttProject.php
@@ -29,7 +29,7 @@ use PhpOffice\PhpProject\Task;
  * @package        PHPProject
  * @copyright    Copyright (c) 2012 - 2012 PHPProject (https://github.com/PHPOffice/PHPProject)
  */
-class GanttProject
+class GanttProject implements ReaderInterface
 {
     /**
      * PHPProject object
@@ -98,7 +98,6 @@ class GanttProject
     
     /**
      * Node "Description"
-     * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
     private function readNodeDescription(\DOMElement $domNode)
@@ -169,8 +168,8 @@ class GanttProject
     }
     /**
      * Node "Resource"
-     * @param XMLReader $oXML
      * @param \DOMElement $domNode
+     * @param Resource $oResource
      */
     private function readNodeResource(\DOMElement $domNode, Resource $oResource)
     {
@@ -197,7 +196,6 @@ class GanttProject
     }
     /**
      * Node "Allocation"
-     * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
     private function readNodeAllocation(\DOMElement $domNode)

--- a/src/PhpProject/Reader/MsProjectMPX.php
+++ b/src/PhpProject/Reader/MsProjectMPX.php
@@ -27,7 +27,7 @@ use PhpOffice\PhpProject\Task;
  * @package        PHPProject
  * @copyright    Copyright (c) 2012 - 2012 PHPProject (https://github.com/PHPOffice/PHPProject)
  */
-class MsProjectMPX
+class MsProjectMPX implements ReaderInterface
 {
     /**
      * PHPProject object

--- a/src/PhpProject/Reader/ReaderInterface.php
+++ b/src/PhpProject/Reader/ReaderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PhpOffice\PhpProject\Reader;
+
+interface ReaderInterface
+{
+    /**
+     * Can the current ReaderInterface read the file?
+     *
+     * @param  string $pFilename
+     * @return bool
+     */
+    public function canRead($pFilename);
+
+    /**
+     * Loads PHPProject from file
+     *
+     * @param  string $pFilename
+     * @return \PhpOffice\PhpProject\PhpProject
+     */
+    public function load($pFilename);
+}

--- a/src/PhpProject/Resource.php
+++ b/src/PhpProject/Resource.php
@@ -65,7 +65,7 @@ class Resource
      * Set title
      *
      * @param string $pTitle Title of the resource
-     * @return PHPProject_Resource
+     * @return self
      */
     public function setTitle($pTitle)
     {
@@ -76,7 +76,7 @@ class Resource
     /**
      * Get index
      *
-     * @return index
+     * @return int
      */
     public function getIndex()
     {

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -78,7 +78,7 @@ class Task
     /**
      * Collection of task objects
      *
-     * @var PHPProject_Task[]
+     * @var self[]
      */
     private $taskCollection = array();
     
@@ -108,7 +108,7 @@ class Task
      * Set name
      *
      * @param string $pValue Name of the task
-     * @return PHPProject_Task
+     * @return self
      */
     public function setName($pValue)
     {
@@ -130,7 +130,7 @@ class Task
      * Set duration (in days)
      *
      * @param string $pValue Duration of the resource
-     * @return PHPProject_Task
+     * @return self
      */
     public function setDuration($pValue)
     {
@@ -141,7 +141,7 @@ class Task
     /**
      * Get Start Date
      *
-     * @return    datetime
+     * @return int
      */
     public function getStartDate()
     {
@@ -152,7 +152,7 @@ class Task
      * Set Start Date
      *
      * @param int $pValue
-     * @return DocumentInformations
+     * @return self
      */
     public function setStartDate($pValue = null)
     {
@@ -173,7 +173,7 @@ class Task
     /**
      * Get End Date
      *
-     * @return    datetime
+     * @return int
      */
     public function getEndDate()
     {
@@ -184,7 +184,7 @@ class Task
      * Set End Date
      *
      * @param int $pValue
-     * @return DocumentInformations
+     * @return self
      */
     public function setEndDate($pValue = null)
     {
@@ -216,7 +216,7 @@ class Task
      * Set progress
      *
      * @param float $pValue Progress of the task
-     * @return PHPProject_Task
+     * @return self
      */
     public function setProgress($pValue = 0)
     {
@@ -259,7 +259,7 @@ class Task
     //===============================================
     /**
      * Add a resource used by the current task
-     * @param PHPProject_Resource $pResource
+     * @param Resource $oResource
      */
     public function addResource(Resource $oResource)
     {
@@ -297,7 +297,7 @@ class Task
     /**
      * Returns a collection of all subtasks created in the task
      *
-     * @return PHPProject_Task[]
+     * @return self[]
      */
     public function getTasks()
     {

--- a/src/PhpProject/Writer/GanttProject.php
+++ b/src/PhpProject/Writer/GanttProject.php
@@ -28,7 +28,7 @@ use PhpOffice\PhpProject\Task;
  * @package        PHPProject
  * @copyright    Copyright (c) 2012 - 2012 PHPProject (https://github.com/PHPOffice/PHPProject)
  */
-class GanttProject
+class GanttProject implements WriterInterface
 {
     /**
      * PHPProject object
@@ -58,7 +58,7 @@ class GanttProject
     /**
      * 
      * @param string $pFilename
-     * @throws Exception
+     * @throws \Exception
      */
     public function save($pFilename)
     {
@@ -375,7 +375,7 @@ class GanttProject
     }
     
     /**
-     * @return multitype:Ambigous <number, unknown>
+     * @return array
      */
     private function sanitizeProject()
     {
@@ -404,7 +404,7 @@ class GanttProject
      * Permits to clean a task
      * - If the duration is not filled, but the end date is, we calculate it.
      * - If the end date is not filled, but the duration is, we calculate it.
-     * @param PHPProject_Task $oTask
+     * @param Task $oTask
      */
     private function sanitizeTask(Task $oTask)
     {
@@ -417,14 +417,14 @@ class GanttProject
             $iNumDays = $iTimeDiff / 60 / 60 / 24;
             $oTask->setDuration($iNumDays + 1);
         } elseif (!is_null($pDuration) && is_null($pEndDate)) {
-            $oTask->setEndDate($pStartDate + ($pDuration * 24 * 60 * 60));
+            $oTask->setEndDate($pStartDate + ((int) $pDuration * 24 * 60 * 60));
         }
     }
     
     /**
      * Permits to clean parent task and calculate parent data like total duration,
      *   date start and complete average.
-     * @param PHPProject_Task $oParentTask
+     * @param Task $oParentTask
      */
     private function sanitizeTaskParent(Task $oParentTask)
     {

--- a/src/PhpProject/Writer/MsProjectMPX.php
+++ b/src/PhpProject/Writer/MsProjectMPX.php
@@ -28,7 +28,7 @@ use PhpOffice\PhpProject\Task;
  * @package        PHPProject
  * @copyright    Copyright (c) 2012 - 2012 PHPProject (https://github.com/PHPOffice/PHPProject)
  */
-class MsProjectMPX
+class MsProjectMPX implements WriterInterface
 {
     /**
      * PHPProject object
@@ -57,7 +57,7 @@ class MsProjectMPX
     /**
      * 
      * @param string $pFilename
-     * @throws Exception
+     * @throws \Exception
      */
     public function save($pFilename)
     {
@@ -96,7 +96,7 @@ class MsProjectMPX
     }
     
     /**
-     * @return multitype:Ambigous <number, unknown>
+     * @return array
      */
     private function sanitizeProject()
     {
@@ -125,7 +125,7 @@ class MsProjectMPX
      * Permits to clean a task
      * - If the duration is not filled, but the end date is, we calculate it.
      * - If the end date is not filled, but the duration is, we calculate it.
-     * @param PHPProject_Task $oTask
+     * @param Task $oTask
      */
     private function sanitizeTask(Task $oTask)
     {
@@ -138,14 +138,14 @@ class MsProjectMPX
             $iNumDays = $iTimeDiff / 60 / 60 / 24;
             $oTask->setDuration($iNumDays + 1);
         } elseif (!is_null($pDuration) && is_null($pEndDate)) {
-            $oTask->setEndDate($pStartDate + ($pDuration * 24 * 60 * 60));
+            $oTask->setEndDate($pStartDate + ((int) $pDuration * 24 * 60 * 60));
         }
     }
     
     /**
      * Permits to clean parent task and calculate parent data like total duration,
      *   date start and complete average.
-     * @param PHPProject_Task $oParentTask
+     * @param Task $oParentTask
      */
     private function sanitizeTaskParent(Task $oParentTask)
     {

--- a/src/PhpProject/Writer/WriterInterface.php
+++ b/src/PhpProject/Writer/WriterInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpOffice\PhpProject\Writer;
+
+interface WriterInterface
+{
+    /**
+     * Save PHPProject to file
+     *
+     * @param  string $pFilename
+     * @return void
+     */
+    public function save($pFilename);
+}


### PR DESCRIPTION
- Create `Reader/ReaderInterface` and `Writer/WriterInterface`, implemented in concrete Reader/Writer classes
- Update obsolete PHPDoc class references (`PHPProject_*` → `self` or correct class name)
- Replace invalid PHPDoc types (`datetime` → `int`, `index` → `int`, `multitype` → `array`, `Exception` → `\Exception`)
- Fix `PhpProject::setInformations()` PHPDoc parameter type (was `DocumentProperties`, now `DocumentInformations`)
- Fix `Task::setStartDate()/setEndDate()` PHPDoc return type (was `DocumentInformations`, now `self`)
- Fix string/int operation in `Writer/GanttProject` and `Writer/MsProjectMPX::sanitizeTask` (explicit `(int)` cast on duration)
- Add explicit `return null;` in `DocumentProperties::getCustomPropertyValue/Type()`
- Remove phantom `@param XMLReader $oXML` PHPDoc tags in `Reader/GanttProject`
- Bump phpstan analysis level from 1 to 2
