### PR TITLE
Bump phpstan analysis level from 2 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@
 - Fixed `Task::setStartDate()/setEndDate()` PHPDoc return type (was `DocumentInformations`, now `self`) - @slayerfx GH-32
 - Fixed string/int operation in `Writer/GanttProject` and `Writer/MsProjectMPX::sanitizeTask` (explicit `(int)` cast on duration) - @slayerfx GH-32
 - Added explicit `return null;` in `DocumentProperties::getCustomPropertyValue/Type()` - @slayerfx GH-32
+- Fixed `Reader::canRead()` PHPDoc return type in `GanttProject` and `MsProjectMPX` (was `PHPProject`, now `bool`) - @slayerfx GH-33
+- Fixed `PhpProject::getActiveTask()` PHPDoc return type (can return null, now `Task|null`) - @slayerfx GH-33
+- Fixed `DocumentProperties::$customProperties` PHPDoc with array shape (was `string[]`, now `array<string, array{value: mixed, type: string}>`) - @slayerfx GH-33
+- Fixed PHPDoc types in `Task`, `XMLReader` and `XmlDocument` to match actual code behavior - @slayerfx GH-33
+- Added `instanceof \DOMElement` check in `XmlDocument::getElement()` to guarantee `DOMElement|null` return - @slayerfx GH-33
 
 ### Miscellaneous
+- Bumped phpstan analysis level from 2 to 3 - @slayerfx GH-33
 - Bumped phpstan analysis level from 1 to 2 - @slayerfx GH-32
 - Created `Reader/ReaderInterface` and `Writer/WriterInterface`, implemented in concrete Reader/Writer classes - @slayerfx GH-32
 - Updated obsolete PHPDoc class references (`PHPProject_*` → `self` or correct class name) - @slayerfx GH-32

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 3
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -115,7 +115,7 @@ class DocumentProperties
     /**
      * Custom Properties
      *
-     * @var    string[]
+     * @var array<string, array{value: mixed, type: string}>
      */
     private $customProperties    = array();
 

--- a/src/PhpProject/PhpProject.php
+++ b/src/PhpProject/PhpProject.php
@@ -216,7 +216,7 @@ class PhpProject
     /**
      * Get active task
      *
-     * @return Task
+     * @return Task|null
      */
     public function getActiveTask()
     {

--- a/src/PhpProject/Reader/GanttProject.php
+++ b/src/PhpProject/Reader/GanttProject.php
@@ -48,7 +48,7 @@ class GanttProject implements ReaderInterface
     /**
      *
      * @param string $pFilename
-     * @return PHPProject
+     * @return bool
      */
     public function canRead($pFilename)
     {

--- a/src/PhpProject/Reader/MsProjectMPX.php
+++ b/src/PhpProject/Reader/MsProjectMPX.php
@@ -70,7 +70,7 @@ class MsProjectMPX implements ReaderInterface
     /**
      *
      * @param string $pFilename
-     * @return PHPProject
+     * @return bool
      */
     public function canRead($pFilename)
     {

--- a/src/PhpProject/Shared/XMLReader.php
+++ b/src/PhpProject/Shared/XMLReader.php
@@ -83,7 +83,7 @@ class XMLReader
      *
      * @param string $path
      * @param \DOMElement $contextNode
-     * @return \DOMNodeList
+     * @return \DOMNodeList|array
      */
     public function getElements($path, ?\DOMElement $contextNode = null)
     {
@@ -102,7 +102,7 @@ class XMLReader
      *
      * @param string $path
      * @param \DOMElement $contextNode
-     * @return \DOMElement|null
+     * @return \DOMNode|null
      */
     public function getElement($path, ?\DOMElement $contextNode = null)
     {

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -69,9 +69,9 @@ class Task
     private $index;
     
     /**
-     * Collection of PHPProject_Resource index
+     * Collection of Resource
      * 
-     * @var integer[]
+     * @var Resource[]
      */
     private $resourceCollection = array();
     

--- a/tests/PhpProject/Tests/_includes/XmlDocument.php
+++ b/tests/PhpProject/Tests/_includes/XmlDocument.php
@@ -39,7 +39,7 @@ class XmlDocument
     /**
      * DOMXpath object
      *
-     * @var \DOMXpath
+     * @var \DOMXpath|null
      */
     private $xpath;
 
@@ -106,12 +106,16 @@ class XmlDocument
      *
      * @param string $path
      * @param string $file
-     * @return \DOMElement
+     * @return \DOMElement|null
      */
     public function getElement($path, $file = 'word/document.xml')
     {
         $elements = $this->getNodeList($path, $file);
-        return $elements->item(0);
+        $item = $elements->item(0);
+        if ($item instanceof \DOMElement) {
+            return $item;
+        }
+        return null;
     }
 
     /**
@@ -153,7 +157,7 @@ class XmlDocument
      * @param   string  $path
      * @param   string  $attribute
      * @param   string  $file
-     * @return  string
+     * @return  bool
      */
     public function attributeElementExists($path, $attribute, $file = 'word/document.xml')
     {
@@ -165,7 +169,7 @@ class XmlDocument
      *
      * @param   string  $path
      * @param   string  $file
-     * @return  string
+     * @return  bool
      */
     public function elementExists($path, $file = 'word/document.xml')
     {


### PR DESCRIPTION
- Bump phpstan analysis level from 2 to 3
- Fix `PhpProject::getActiveTask()` PHPDoc return type (`Task` → `Task|null`)
- Fix `Reader::canRead()` PHPDoc return type in `GanttProject` and `MsProjectMPX` (`PHPProject` → `bool`)
- Fix `Task::$resourceCollection` PHPDoc (`integer[]` → `Resource[]`)
- Fix `DocumentProperties::$customProperties` PHPDoc with array shape
- Fix `XMLReader::getElements()` and `getElement()` PHPDoc return types
- Fix `XmlDocument` tests PHPDocs and add `instanceof \DOMElement` check in `getElement()`
