### PR TITLE
Bump phpstan analysis level from 3 to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@
 - Fixed `DocumentProperties::$customProperties` PHPDoc with array shape (was `string[]`, now `array<string, array{value: mixed, type: string}>`) - @slayerfx GH-33
 - Fixed PHPDoc types in `Task`, `XMLReader` and `XmlDocument` to match actual code behavior - @slayerfx GH-33
 - Added `instanceof \DOMElement` check in `XmlDocument::getElement()` to guarantee `DOMElement|null` return - @slayerfx GH-33
+- Broadened PHPDoc parameter types for setter methods accepting flexible inputs (`int` → `int|string|null` in `DocumentInformations`, `DocumentProperties`) - @slayerfx GH-34
+- Broadened PHPDoc return types for nullable getters in `Task` (`getDuration`, `getStartDate`, `getEndDate`, `getProgress` — added `|null`) - @slayerfx GH-34
+- Fixed `Reader/MsProjectMPX::$iParentTaskIdx` PHPDoc (was `integer`, now `integer|null`) - @slayerfx GH-34
 
 ### Miscellaneous
+- Bumped phpstan analysis level from 3 to 4 - @slayerfx GH-34
 - Bumped phpstan analysis level from 2 to 3 - @slayerfx GH-33
 - Bumped phpstan analysis level from 1 to 2 - @slayerfx GH-32
 - Created `Reader/ReaderInterface` and `Writer/WriterInterface`, implemented in concrete Reader/Writer classes - @slayerfx GH-32

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/src/PhpProject/DocumentInformations.php
+++ b/src/PhpProject/DocumentInformations.php
@@ -56,7 +56,7 @@ class DocumentInformations
 
     /**
      * Set Start Date
-     * @param int $pValue
+     * @param int|string|null $pValue
      * @return DocumentInformations
      */
     public function setStartDate($pValue = null)
@@ -85,7 +85,7 @@ class DocumentInformations
 
     /**
      * Set End Date
-     * @param int $pValue
+     * @param int|string|null $pValue
      * @return DocumentInformations
      */
     public function setEndDate($pValue = null)

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -186,7 +186,7 @@ class DocumentProperties
     /**
      * Set Created
      *
-     * @param    int    $pValue
+     * @param int|string|null $pValue
      * @return    self
      */
     public function setCreated($pValue = null)
@@ -218,7 +218,7 @@ class DocumentProperties
     /**
      * Set Modified
      *
-     * @param    int    $pValue
+     * @param int|string|null $pValue
      * @return    self
      */
     public function setModified($pValue = null)

--- a/src/PhpProject/Reader/MsProjectMPX.php
+++ b/src/PhpProject/Reader/MsProjectMPX.php
@@ -50,7 +50,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Index in $defTask for the precedessor
-     * @var integer
+     * @var int|null
      */
     private $iParentTaskIdx;
     

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -119,7 +119,7 @@ class Task
     /**
      * Get duration
      *
-     * @return string
+     * @return string|null
      */
     public function getDuration()
     {
@@ -141,7 +141,7 @@ class Task
     /**
      * Get Start Date
      *
-     * @return int
+     * @return int|null
      */
     public function getStartDate()
     {
@@ -151,7 +151,7 @@ class Task
     /**
      * Set Start Date
      *
-     * @param int $pValue
+     * @param int|string|null $pValue
      * @return self
      */
     public function setStartDate($pValue = null)
@@ -173,7 +173,7 @@ class Task
     /**
      * Get End Date
      *
-     * @return int
+     * @return int|null
      */
     public function getEndDate()
     {
@@ -183,7 +183,7 @@ class Task
     /**
      * Set End Date
      *
-     * @param int $pValue
+     * @param int|string|null $pValue
      * @return self
      */
     public function setEndDate($pValue = null)
@@ -205,7 +205,7 @@ class Task
     /**
      * Get Progress
      *
-     * @return float
+     * @return float|null
      */
     public function getProgress()
     {


### PR DESCRIPTION
- Broaden PHPDoc parameter types for setter methods accepting flexible inputs (`int` → `int|string|null` in `DocumentInformations`, `DocumentProperties`)
- Broaden PHPDoc return types for nullable getters in `Task` (`getDuration`, `getStartDate`, `getEndDate`, `getProgress` — added `|null`)
- Fix `Reader/MsProjectMPX::$iParentTaskIdx` PHPDoc (was `integer`, now `integer|null`)
- Bump phpstan analysis level from 3 to 4
