### PR TITLE
Bump phpstan analysis level from 4 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@
 - Broadened PHPDoc parameter types for setter methods accepting flexible inputs (`int` → `int|string|null` in `DocumentInformations`, `DocumentProperties`) - @slayerfx GH-34
 - Broadened PHPDoc return types for nullable getters in `Task` (`getDuration`, `getStartDate`, `getEndDate`, `getProgress` — added `|null`) - @slayerfx GH-34
 - Fixed `Reader/MsProjectMPX::$iParentTaskIdx` PHPDoc (was `integer`, now `integer|null`) - @slayerfx GH-34
+- Broadened PHPDoc parameter types in `Task::setIndex/setProgress/setDuration` and `Resource::setIndex` to accept multiple types handled in practice - @slayerfx GH-35
+- Broadened `XMLReader::getElement` and `getElements` `$contextNode` parameter to `?\DOMNode` (was `?\DOMElement`) - @slayerfx GH-35
+- Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
+- Bumped phpstan analysis level from 4 to 5 - @slayerfx GH-35
 - Bumped phpstan analysis level from 3 to 4 - @slayerfx GH-34
 - Bumped phpstan analysis level from 2 to 3 - @slayerfx GH-33
 - Bumped phpstan analysis level from 1 to 2 - @slayerfx GH-32

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 4
+  level: 5
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/src/PhpProject/Resource.php
+++ b/src/PhpProject/Resource.php
@@ -85,7 +85,7 @@ class Resource
     
     /**
      * Set index
-     * @param integer $value
+     * @param int|string $value
      */
     public function setIndex($value)
     {

--- a/src/PhpProject/Shared/XMLReader.php
+++ b/src/PhpProject/Shared/XMLReader.php
@@ -82,10 +82,10 @@ class XMLReader
      * Get elements
      *
      * @param string $path
-     * @param \DOMElement $contextNode
+     * @param \DOMNode $contextNode
      * @return \DOMNodeList|array
      */
-    public function getElements($path, ?\DOMElement $contextNode = null)
+    public function getElements($path, ?\DOMNode $contextNode = null)
     {
         if ($this->dom === null) {
             return array();
@@ -101,24 +101,24 @@ class XMLReader
      * Get element
      *
      * @param string $path
-     * @param \DOMElement $contextNode
-     * @return \DOMNode|null
+     * @param \DOMNode|null $contextNode
+     * @return \DOMElement|null
      */
-    public function getElement($path, ?\DOMElement $contextNode = null)
+    public function getElement($path, ?\DOMNode $contextNode = null)
     {
         $elements = $this->getElements($path, $contextNode);
-        if ($elements->length > 0) {
-            return $elements->item(0);
-        } else {
-            return null;
+        $item = $elements->item(0);
+        if ($item instanceof \DOMElement) {
+            return $item;
         }
+        return null;
     }
 
     /**
      * Get element attribute
      *
      * @param string $attribute
-     * @param \DOMElement $contextNode
+     * @param \DOMElement|null $contextNode
      * @param string $path
      * @return string|null
      */

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -129,7 +129,7 @@ class Task
     /**
      * Set duration (in days)
      *
-     * @param string $pValue Duration of the resource
+     * @param int|float|string $pValue Duration of the resource
      * @return self
      */
     public function setDuration($pValue)
@@ -215,7 +215,7 @@ class Task
     /**
      * Set progress
      *
-     * @param float $pValue Progress of the task
+     * @param int|float|string $pValue Progress of the task
      * @return self
      */
     public function setProgress($pValue = 0)
@@ -244,7 +244,7 @@ class Task
     
     /**
      * Set index
-     * @param integer $value
+     * @param int|string $value
      */
     public function setIndex($value)
     {


### PR DESCRIPTION
- Broaden PHPDoc parameter types in `Task::setIndex/setProgress/setDuration` and `Resource::setIndex` to accept multiple types handled in practice
- Broaden `XMLReader::getElement` and `getElements` `$contextNode` parameter to `?\DOMNode` (was `?\DOMElement`)
- Restrict `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check
- Bump phpstan analysis level from 4 to 5
