### PR TITLE
Apply PhpProject casing consistently across PR #36 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
+- Applied `PhpProject` casing consistently in README, mkdocs.yml, samples and docs - @slayerfx GH-37
 - Migrated documentation from Sphinx (RST) to MkDocs (Markdown) - @slayerfx GH-36
 - Added GitHub Actions deploy workflow for documentation (mkdocs + PHPUnit coverage HTML + phpDocumentor) - @slayerfx GH-36
 - Removed Sphinx configuration files (`docs/conf.py`, `docs/Makefile`) - @slayerfx GH-36

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PHPProject
+# PhpProject
 
 [![Latest Stable Version](https://poser.pugx.org/phpoffice/phpproject/v/stable.png)](https://packagist.org/packages/phpoffice/phpproject)
 [![Coverage Status](https://coveralls.io/repos/github/PHPOffice/PhpProject/badge.svg?branch=develop)](https://coveralls.io/github/PHPOffice/PhpProject?branch=develop)
@@ -6,10 +6,10 @@
 [![License](https://poser.pugx.org/phpoffice/phpproject/license.png)](https://packagist.org/packages/phpoffice/phpproject)
 
 
-PHPProject is a library written in pure PHP that provides a set of classes to write to different project management file formats, i.e. Microsoft [MSProjectExchange](http://support.microsoft.com/kb/270139) (MPX) or [GanttProject](http://www.ganttproject.biz) (GAN). 
-PhpProject is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PHPProject/blob/develop/COPYING.LESSER). PhpProject is aimed to be a high quality software product by incorporating continuous integration and [unit testing](https://phpoffice.github.io/PhpProject/coverage/). You can learn more about PhpProject by reading the [Developers' Documentation](https://phpoffice.github.io/PhpProject/) and the [API Documentation](https://phpoffice.github.io/PhpProject/docs/).
+PhpProject is a library written in pure PHP that provides a set of classes to write to different project management file formats, i.e. Microsoft [MSProjectExchange](http://support.microsoft.com/kb/270139) (MPX) or [GanttProject](http://www.ganttproject.biz) (GAN). 
+PhpProject is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PhpProject/blob/develop/COPYING.LESSER). PhpProject is aimed to be a high quality software product by incorporating continuous integration and [unit testing](https://phpoffice.github.io/PhpProject/coverage/). You can learn more about PhpProject by reading the [Developers' Documentation](https://phpoffice.github.io/PhpProject/) and the [API Documentation](https://phpoffice.github.io/PhpProject/docs/).
 
-Read more about PHPProject:
+Read more about PhpProject:
 
 - [Features](#features)
 - [Requirements](#requirements)
@@ -31,14 +31,14 @@ Read more about PHPProject:
 
 ### Requirements
 
-PHPProject requires the following:
+PhpProject requires the following:
 
 - PHP 5.3+
 - [XML Parser extension](http://www.php.net/manual/en/xml.installation.php)
 
 ### Installation
 
-It is recommended that you install the PHPProject library [through composer](http://getcomposer.org/). To do so, add
+It is recommended that you install the PhpProject library [through composer](http://getcomposer.org/). To do so, add
 the following lines to your ``composer.json``.
 
 ```json
@@ -49,7 +49,7 @@ the following lines to your ``composer.json``.
 }
 ```
 
-Alternatively, you can download the latest release from the [releases page](https://github.com/PHPOffice/PHPProject/releases).
+Alternatively, you can download the latest release from the [releases page](https://github.com/PHPOffice/PhpProject/releases).
 In this case, you will have to register the autoloader. Register autoloading is required only if you do not use composer in your project.
 
 ```php
@@ -59,7 +59,7 @@ require_once 'path/to/PhpProject/src/PhpProject/Autoloader.php';
 
 ## Getting started
 
-The following is a basic usage example of the PHPProject library.
+The following is a basic usage example of the PhpProject library.
 
 ```php
 require_once 'src/PhpProject/Autoloader.php';
@@ -88,9 +88,9 @@ More examples are provided in the [samples folder](samples/). You can also read 
 
 ## Contributing
 
-We welcome everyone to contribute to PHPProject. Below are some of the things that you can do to contribute:
+We welcome everyone to contribute to PhpProject. Below are some of the things that you can do to contribute:
 
-- Read [our contributing guide](https://github.com/PHPOffice/PHPProject/blob/master/CONTRIBUTING.md)
-- [Fork us](https://github.com/PHPOffice/PHPProject/fork) and [request a pull](https://github.com/PHPOffice/PHPProject/pulls) to the [develop](https://github.com/PHPOffice/PHPProject/tree/develop) branch
-- Submit [bug reports or feature requests](https://github.com/PHPOffice/PHPProject/issues) to GitHub
+- Read [our contributing guide](https://github.com/PHPOffice/PhpProject/blob/master/CONTRIBUTING.md)
+- [Fork us](https://github.com/PHPOffice/PhpProject/fork) and [request a pull](https://github.com/PHPOffice/PhpProject/pulls) to the [develop](https://github.com/PHPOffice/PhpProject/tree/develop) branch
+- Submit [bug reports or feature requests](https://github.com/PHPOffice/PhpProject/issues) to GitHub
 - Follow [@PHPOffice](https://twitter.com/PHPOffice) on Twitter

--- a/docs/general.md
+++ b/docs/general.md
@@ -2,7 +2,7 @@
 
 ## Basic example
 
-The following is a basic example of the PHPProject library. More examples are provided in the [samples folder](https://github.com/PHPOffice/PHPProject/tree/master/samples/).
+The following is a basic example of the PhpProject library. More examples are provided in the [samples folder](https://github.com/PHPOffice/PhpProject/tree/master/samples/).
 
 ``` php
 require_once 'src/PhpProject/Autoloader.php';

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
-# Welcome to PHPProject's documentation
+# Welcome to PhpProject's documentation
 
-PHPProject is a library written in pure PHP that provides a set of classes to write to different project managements file formats, i.e. GanttProject (.gan) and MS-Project (.mpx). PHPProject is an open source project licensed under LGPL.
+PhpProject is a library written in pure PHP that provides a set of classes to write to different project managements file formats, i.e. GanttProject (.gan) and MS-Project (.mpx). PhpProject is an open source project licensed under LGPL.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -13,7 +13,7 @@ Optional PHP extensions:
 
 ## Installation
 
-There are two ways to install PHPProject, i.e. via [Composer](http://getcomposer.org/) or manually by downloading the library.
+There are two ways to install PhpProject, i.e. via [Composer](http://getcomposer.org/) or manually by downloading the library.
 
 ### Using Composer
 
@@ -29,7 +29,7 @@ To install via Composer, add the following lines to your `composer.json`:
 
 ### Manual install
 
-To install manually, [download PHPProject package from github](https://github.com/PHPOffice/PHPProject/archive/master.zip). Extract the package and put the contents to your machine. To use the library, include `src/PHPProject/Autoloader.php` in your script and invoke `Autoloader::register`.
+To install manually, [download PhpProject package from github](https://github.com/PHPOffice/PhpProject/archive/master.zip). Extract the package and put the contents to your machine. To use the library, include `src/PhpProject/Autoloader.php` in your script and invoke `Autoloader::register`.
 
 ``` php
 require_once '/path/to/src/PhpProject/Autoloader.php';
@@ -38,4 +38,4 @@ require_once '/path/to/src/PhpProject/Autoloader.php';
 
 ## Using samples
 
-After installation, you can browse and use the samples that we've provided, either by command line or using browser. If you can access your PHPProject library folder using browser, point your browser to the `samples` folder, e.g. `http://localhost/PhpProject/samples/`.
+After installation, you can browse and use the samples that we've provided, either by command line or using browser. If you can access your PhpProject library folder using browser, point your browser to the `samples` folder, e.g. `http://localhost/PhpProject/samples/`.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,8 +1,8 @@
 # Introduction
 
-PHPProject is a library written in pure PHP that provides a set of classes to write to different project management file formats, i.e. Microsoft [MSProjectExchange](http://support.microsoft.com/kb/270139) (.mpx) and [GanttProject](http://www.ganttproject.biz/) (.gan).
+PhpProject is a library written in pure PHP that provides a set of classes to write to different project management file formats, i.e. Microsoft [MSProjectExchange](http://support.microsoft.com/kb/270139) (.mpx) and [GanttProject](http://www.ganttproject.biz/) (.gan).
 
-PHPProject is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PHPProject/blob/develop/COPYING.LESSER). PHPProject is aimed to be a high quality software product by incorporating continuous integration and [unit testing](https://phpoffice.github.io/PHPProject/coverage/). You can learn more about PHPProject by reading this Developers' Documentation and the [API Documentation](https://phpoffice.github.io/PHPProject/docs/).
+PhpProject is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PhpProject/blob/develop/COPYING.LESSER). PhpProject is aimed to be a high quality software product by incorporating continuous integration and [unit testing](https://phpoffice.github.io/PhpProject/coverage/). You can learn more about PhpProject by reading this Developers' Documentation and the [API Documentation](https://phpoffice.github.io/PhpProject/docs/).
 
 ## Features
 
@@ -41,9 +41,9 @@ Below are the supported features for each file formats.
 
 ## Contributing
 
-We welcome everyone to contribute to PHPProject. Below are some of the things that you can do to contribute:
+We welcome everyone to contribute to PhpProject. Below are some of the things that you can do to contribute:
 
-- Read [our contributing guide](https://github.com/PHPOffice/PHPProject/blob/master/CONTRIBUTING.md)
-- [Fork us](https://github.com/PHPOffice/PHPProject/fork) and [request a pull](https://github.com/PHPOffice/PHPProject/pulls) to the [develop](https://github.com/PHPOffice/PHPProject/tree/develop) branch
-- Submit [bug reports or feature requests](https://github.com/PHPOffice/PHPProject/issues) to GitHub
+- Read [our contributing guide](https://github.com/PHPOffice/PhpProject/blob/master/CONTRIBUTING.md)
+- [Fork us](https://github.com/PHPOffice/PhpProject/fork) and [request a pull](https://github.com/PHPOffice/PhpProject/pulls) to the [develop](https://github.com/PHPOffice/PhpProject/tree/develop) branch
+- Submit [bug reports or feature requests](https://github.com/PHPOffice/PhpProject/issues) to GitHub
 - Follow [@PHPOffice](https://twitter.com/PHPOffice) on Twitter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,4 +48,4 @@ nav:
   - Credits: "credits.md"
   - References: "references.md"
   - Developers:
-    - "Coveralls": "https://coveralls.io/github/PHPOffice/PHPProject"
+    - "Coveralls": "https://coveralls.io/github/PHPOffice/PhpProject"

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -25,7 +25,7 @@ if (CLI) {
 // Set titles and names
 $pageHeading = str_replace('_', ' ', SCRIPT_FILENAME);
 $pageTitle = IS_INDEX ? 'Welcome to ' : "{$pageHeading} - ";
-$pageTitle .= 'PHPProject';
+$pageTitle .= 'PhpProject';
 $pageHeading = IS_INDEX ? '' : "<h1>{$pageHeading}</h1>";
 
 // Populate samples
@@ -149,7 +149,7 @@ function echoTask($oPHPProject, $oTask, $level = 0) {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="./">PHPProject</a>
+            <a class="navbar-brand" href="./">PhpProject</a>
         </div>
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
@@ -159,7 +159,7 @@ function echoTask($oPHPProject, $oTask, $level = 0) {
                 </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="https://github.com/PHPOffice/PHPProject"><i class="fa fa-github fa-lg" title="GitHub"></i>&nbsp;</a></li>
+                <li><a href="https://github.com/PHPOffice/PhpProject"><i class="fa fa-github fa-lg" title="GitHub"></i>&nbsp;</a></li>
                 <li><a href="https://phpoffice.github.io/PhpProject/"><i class="fa fa-book fa-lg" title="Docs"></i>&nbsp;</a></li>
                 <li><a href="http://twitter.com/PHPOffice"><i class="fa fa-twitter fa-lg" title="Twitter"></i>&nbsp;</a></li>
             </ul>

--- a/samples/index.php
+++ b/samples/index.php
@@ -9,10 +9,10 @@ $requirements = array(
 if (!CLI) {
 ?>
 <div class="jumbotron">
-<p>Welcome to PHPProject, a library written in pure PHP that provides a set of classes to write to and read from different document file formats, i.e. GanttProject (.gan) and MS Project (.mpx).</p>
+<p>Welcome to PhpProject, a library written in pure PHP that provides a set of classes to write to and read from different document file formats, i.e. GanttProject (.gan) and MS Project (.mpx).</p>
 <p>&nbsp;</p>
 <p>
-    <a class="btn btn-lg btn-primary" href="https://github.com/PHPOffice/PHPProject" role="button"><i class="fa fa-github fa-lg" title="GitHub"></i>  Fork us on Github!</a>
+    <a class="btn btn-lg btn-primary" href="https://github.com/PHPOffice/PhpProject" role="button"><i class="fa fa-github fa-lg" title="GitHub"></i>  Fork us on Github!</a>
     <a class="btn btn-lg btn-primary" href="https://phpoffice.github.io/PhpProject/" role="button"><i class="fa fa-book fa-lg" title="Docs"></i>  Read the Docs</a>
 </p>
 </div>


### PR DESCRIPTION
- `README.md`: title, paragraphs, remaining GitHub links
- `mkdocs.yml`: missed Coveralls link in nav
- `samples/index.php`: welcome text + GitHub URL
- `samples/Sample_Header.php`: page title, navbar brand, GitHub URL
- `docs/{index,intro,installing,general}.md`: text and URLs (including a fix for `src/PHPProject/` → `src/PhpProject/` in installing.md, which is the actual case-sensitive path on Linux)

