### PR TITLE
Type method signatures of core classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of `Resource` class (`setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3) - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of core classes (`Resource`, `DocumentInformations`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`, `Task`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`, `Task`, `Shared\XMLReader`, `Shared\XMLWriter`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Broadened PHPDoc parameter types in `Task::setIndex/setProgress/setDuration` and `Resource::setIndex` to accept multiple types handled in practice - @slayerfx GH-35
 - Broadened `XMLReader::getElement` and `getElements` `$contextNode` parameter to `?\DOMNode` (was `?\DOMElement`) - @slayerfx GH-35
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
+- Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
 - Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`, `Task`, `Shared\XMLReader`, `Shared\XMLWriter`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
+- Typed method signatures of `Resource` class (`setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3) - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 
 ### Miscellaneous
-- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
+- Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`, `Task`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43
 - Added Dependabot configuration to monitor Composer dependencies and GitHub Actions - @slayerfx GH-38

--- a/src/PhpProject/DocumentInformations.php
+++ b/src/PhpProject/DocumentInformations.php
@@ -52,7 +52,7 @@ class DocumentInformations
      * Get Start Date
      * @return int
      */
-    public function getStartDate()
+    public function getStartDate(): ?int
     {
         return $this->startDate;
     }
@@ -60,9 +60,9 @@ class DocumentInformations
     /**
      * Set Start Date
      * @param int|string|null $pValue
-     * @return DocumentInformations
+     * @return self
      */
-    public function setStartDate($pValue = null)
+    public function setStartDate($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();
@@ -81,7 +81,7 @@ class DocumentInformations
      * Get End Date
      * @return int
      */
-    public function getEndDate()
+    public function getEndDate(): ?int
     {
         return $this->endDate;
     }
@@ -89,9 +89,9 @@ class DocumentInformations
     /**
      * Set End Date
      * @param int|string|null $pValue
-     * @return DocumentInformations
+     * @return self
      */
-    public function setEndDate($pValue = null)
+    public function setEndDate($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();

--- a/src/PhpProject/DocumentInformations.php
+++ b/src/PhpProject/DocumentInformations.php
@@ -71,6 +71,9 @@ class DocumentInformations
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
         $this->startDate = $pValue;
@@ -100,6 +103,9 @@ class DocumentInformations
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
         $this->endDate = $pValue;

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -137,7 +137,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getCreator()
+    public function getCreator(): string
     {
         return $this->creator;
     }
@@ -148,7 +148,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setCreator($pValue = '')
+    public function setCreator(string $pValue = ''): self
     {
         $this->creator = $pValue;
         return $this;
@@ -159,7 +159,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getLastModifiedBy()
+    public function getLastModifiedBy(): string
     {
         return $this->lastModifiedBy;
     }
@@ -170,7 +170,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setLastModifiedBy($pValue = '')
+    public function setLastModifiedBy(string $pValue = ''): self
     {
         $this->lastModifiedBy = $pValue;
         return $this;
@@ -181,7 +181,7 @@ class DocumentProperties
      *
      * @return    int
      */
-    public function getCreated()
+    public function getCreated(): ?int
     {
         return $this->created;
     }
@@ -192,7 +192,7 @@ class DocumentProperties
      * @param int|string|null $pValue
      * @return    self
      */
-    public function setCreated($pValue = null)
+    public function setCreated($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();
@@ -213,7 +213,7 @@ class DocumentProperties
      *
      * @return    int
      */
-    public function getModified()
+    public function getModified(): ?int
     {
         return $this->modified;
     }
@@ -224,7 +224,7 @@ class DocumentProperties
      * @param int|string|null $pValue
      * @return    self
      */
-    public function setModified($pValue = null)
+    public function setModified($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();
@@ -245,7 +245,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -256,7 +256,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setTitle($pValue = '')
+    public function setTitle(string $pValue = ''): self
     {
         $this->title = $pValue;
         return $this;
@@ -267,7 +267,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -278,7 +278,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setDescription($pValue = '')
+    public function setDescription(string $pValue = ''): self
     {
         $this->description = $pValue;
         return $this;
@@ -289,7 +289,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->subject;
     }
@@ -300,7 +300,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setSubject($pValue = '')
+    public function setSubject(string $pValue = ''): self
     {
         $this->subject = $pValue;
         return $this;
@@ -311,7 +311,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getKeywords()
+    public function getKeywords(): string
     {
         return $this->keywords;
     }
@@ -322,7 +322,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setKeywords($pValue = '')
+    public function setKeywords(string $pValue = ''): self
     {
         $this->keywords = $pValue;
         return $this;
@@ -333,7 +333,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getCategory()
+    public function getCategory(): string
     {
         return $this->category;
     }
@@ -344,7 +344,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setCategory($pValue = '')
+    public function setCategory(string $pValue = ''): self
     {
         $this->category = $pValue;
         return $this;
@@ -355,7 +355,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getCompany()
+    public function getCompany(): string
     {
         return $this->company;
     }
@@ -366,7 +366,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setCompany($pValue = '')
+    public function setCompany(string $pValue = ''): self
     {
         $this->company = $pValue;
         return $this;
@@ -377,7 +377,7 @@ class DocumentProperties
      *
      * @return    string
      */
-    public function getManager()
+    public function getManager(): string
     {
         return $this->manager;
     }
@@ -388,7 +388,7 @@ class DocumentProperties
      * @param    string    $pValue
      * @return    self
      */
-    public function setManager($pValue = '')
+    public function setManager(string $pValue = ''): self
     {
         $this->manager = $pValue;
         return $this;
@@ -399,7 +399,7 @@ class DocumentProperties
      *
      * @return string[]
      */
-    public function getCustomProperties()
+    public function getCustomProperties(): array
     {
         return array_keys($this->customProperties);
     }
@@ -410,7 +410,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    boolean
      */
-    public function isCustomPropertySet($propertyName)
+    public function isCustomPropertySet(string $propertyName): bool
     {
         return isset($this->customProperties[$propertyName]);
     }
@@ -421,7 +421,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyValue($propertyName)
+    public function getCustomPropertyValue(string $propertyName)
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['value'];
@@ -435,7 +435,7 @@ class DocumentProperties
      * @param    string    $propertyName
      * @return    string|null
      */
-    public function getCustomPropertyType($propertyName)
+    public function getCustomPropertyType(string $propertyName): ?string
     {
         if (isset($this->customProperties[$propertyName])) {
             return $this->customProperties[$propertyName]['type'];
@@ -456,7 +456,7 @@ class DocumentProperties
      *                        'b': Boolean
      * @return    self
      */
-    public function setCustomProperty($propertyName, $propertyValue = '', $propertyType = null)
+    public function setCustomProperty(string $propertyName, $propertyValue = '', ?string $propertyType = null): self
     {
         if (($propertyType === null) || (!in_array($propertyType, array(self::PROPERTY_TYPE_INTEGER, self::PROPERTY_TYPE_FLOAT, self::PROPERTY_TYPE_STRING, self::PROPERTY_TYPE_DATE, self::PROPERTY_TYPE_BOOLEAN)))) {
             if (is_float($propertyValue)) {
@@ -474,7 +474,7 @@ class DocumentProperties
         return $this;
     }
 
-    public static function convertProperty($propertyValue, $propertyType)
+    public static function convertProperty(string $propertyValue, string $propertyType)
     {
         switch ($propertyType) {
             case 'empty': // Empty
@@ -531,7 +531,7 @@ class DocumentProperties
         return $propertyValue;
     }
 
-    public static function convertPropertyType($propertyType)
+    public static function convertPropertyType(string $propertyType): string
     {
         switch ($propertyType) {
             case 'i1': // 1-Byte Signed Integer

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -201,6 +201,9 @@ class DocumentProperties
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
 
@@ -233,6 +236,9 @@ class DocumentProperties
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
 

--- a/src/PhpProject/IOFactory.php
+++ b/src/PhpProject/IOFactory.php
@@ -39,7 +39,7 @@ class IOFactory
      * @param string $name
      * @return \PhpOffice\PhpProject\Writer\WriterInterface
      */
-    public static function createWriter(PhpProject $phpProject, $name = 'GanttProject')
+    public static function createWriter(PhpProject $phpProject, string $name = 'GanttProject'): Writer\WriterInterface
     {
         $class = 'PhpOffice\\PhpProject\\Writer\\' . $name;
         return self::loadClass($class, $name, 'writer', $phpProject);
@@ -51,7 +51,7 @@ class IOFactory
      * @param  string $name
      * @return \PhpOffice\PhpProject\Reader\ReaderInterface
      */
-    public static function createReader($name = 'GanttProject')
+    public static function createReader(string $name = 'GanttProject'): Reader\ReaderInterface
     {
         $class = 'PhpOffice\\PhpProject\\Reader\\' . $name;
         return self::loadClass($class, $name, 'reader');
@@ -64,7 +64,7 @@ class IOFactory
      * @return PhpProject
      * @throws \Exception
      */
-    public static function load($pFilename)
+    public static function load(string $pFilename): PhpProject
     {
         // Try loading using self::$autoResolveClasses
         foreach (self::$autoResolveClasses as $autoResolveClass) {
@@ -87,7 +87,7 @@ class IOFactory
      * @throws \Exception
      * @return \PhpOffice\PhpProject\Reader\ReaderInterface|\PhpOffice\PhpProject\Writer\WriterInterface
      */
-    private static function loadClass($class, $name, $type, ?PhpProject $phpProject = null)
+    private static function loadClass(string $class, string $name, string $type, ?PhpProject $phpProject = null)
     {
         if (class_exists($class) && self::isConcreteClass($class)) {
             if (is_null($phpProject)) {
@@ -106,7 +106,7 @@ class IOFactory
      * @param string $class
      * @return bool
      */
-    private static function isConcreteClass($class)
+    private static function isConcreteClass(string $class): bool
     {
         $reflection = new \ReflectionClass($class);
 

--- a/src/PhpProject/PhpProject.php
+++ b/src/PhpProject/PhpProject.php
@@ -76,7 +76,7 @@ class PhpProject
      *
      * @return DocumentProperties
      */
-    public function getProperties()
+    public function getProperties(): DocumentProperties
     {
         return $this->properties;
     }
@@ -86,7 +86,7 @@ class PhpProject
      *
      * @param DocumentProperties $pValue
      */
-    public function setProperties(DocumentProperties $pValue)
+    public function setProperties(DocumentProperties $pValue): self
     {
         $this->properties = $pValue;
         return $this;
@@ -100,7 +100,7 @@ class PhpProject
      * 
      * @return DocumentInformations
      */
-    public function getInformations()
+    public function getInformations(): DocumentInformations
     {
         return $this->informations;
     }
@@ -110,7 +110,7 @@ class PhpProject
      *
      * @param DocumentInformations $pValue
      */
-    public function setInformations(DocumentInformations $pValue)
+    public function setInformations(DocumentInformations $pValue): self
     {
         $this->informations = $pValue;
         return $this;
@@ -125,7 +125,7 @@ class PhpProject
      * @return Resource
      * @throws \Exception
      */
-    public function createResource()
+    public function createResource(): Resource
     {
         $newRessource = new Resource();
         $this->resourceCollection[] = $newRessource;
@@ -137,7 +137,7 @@ class PhpProject
      *
      * @return int
      */
-    public function getResourceCount()
+    public function getResourceCount(): int
     {
         return count($this->resourceCollection);
     }
@@ -147,7 +147,7 @@ class PhpProject
      *
      * @return \PhpOffice\PhpProject\Resource[]
      */
-    public function getAllResources()
+    public function getAllResources(): array
     {
         return $this->resourceCollection;
     }
@@ -157,7 +157,7 @@ class PhpProject
      *
      * @return Resource|null
      */
-    public function getActiveResource()
+    public function getActiveResource(): ?Resource
     {
         if (!empty($this->resourceCollection)) {
             return end($this->resourceCollection);
@@ -170,7 +170,7 @@ class PhpProject
      *
      * @return Resource|null
      */
-    public function getResourceFromIndex($pIndex)
+    public function getResourceFromIndex($pIndex): ?Resource
     {
         foreach ($this->resourceCollection as $oResource) {
             if ($oResource->getIndex() == $pIndex) {
@@ -189,7 +189,7 @@ class PhpProject
      * @return Task
      * @throws \Exception
      */
-    public function createTask()
+    public function createTask(): Task
     {
         $newTask = new Task();
         $this->taskCollection[] = $newTask;
@@ -201,7 +201,7 @@ class PhpProject
      *
      * @return int
      */
-    public function getTaskCount()
+    public function getTaskCount(): int
     {
         return count($this->taskCollection);
     }
@@ -211,7 +211,7 @@ class PhpProject
      *
      * @return Task[]
      */
-    public function getAllTasks()
+    public function getAllTasks(): array
     {
         return $this->taskCollection;
     }
@@ -221,7 +221,7 @@ class PhpProject
      *
      * @return Task|null
      */
-    public function getActiveTask()
+    public function getActiveTask(): ?Task
     {
         if (!empty($this->taskCollection)) {
             return end($this->taskCollection);
@@ -234,7 +234,7 @@ class PhpProject
      *
      * @return Task|null
      */
-    public function getTaskFromIndex($pIndex, ?Task $oTaskParent = null)
+    public function getTaskFromIndex($pIndex, ?Task $oTaskParent = null): ?Task
     {
         if (is_null($oTaskParent)) {
             $arrayTask = $this->taskCollection;
@@ -262,7 +262,7 @@ class PhpProject
      * @param int $pIndex Active task index
      * @throws \Exception
      */
-    public function removeTaskByIndex($pIndex = 0)
+    public function removeTaskByIndex(int $pIndex = 0): void
     {
         if (!isset($this->taskCollection[$pIndex])) {
             throw new \Exception('Task index is out of bounds.');

--- a/src/PhpProject/Resource.php
+++ b/src/PhpProject/Resource.php
@@ -31,10 +31,10 @@ class Resource
 {
     /**
      * Title
-     * 
+     *
      * @var string
      */
-    private $title;
+    private $title = '';
     
     /**
      * Index
@@ -59,38 +59,40 @@ class Resource
      *
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
-    
+
     /**
      * Set title
      *
      * @param string $pTitle Title of the resource
      * @return self
      */
-    public function setTitle($pTitle)
+    public function setTitle(string $pTitle): self
     {
         $this->title = $pTitle;
         return $this;
     }
-    
+
     /**
      * Get index
      *
      * @return int
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
-    
+
     /**
      * Set index
+     *
      * @param int|string $value
+     * @return self
      */
-    public function setIndex($value)
+    public function setIndex($value): self
     {
         if (is_numeric($value)) {
             $this->index = (int)$value;

--- a/src/PhpProject/Shared/XMLReader.php
+++ b/src/PhpProject/Shared/XMLReader.php
@@ -49,7 +49,7 @@ class XMLReader
      * @return \DOMDocument|false
      * @throws \Exception
      */
-    public function getDomFromZip($zipFile, $xmlFile)
+    public function getDomFromZip(string $zipFile, string $xmlFile)
     {
         if (file_exists($zipFile) === false) {
             throw new \Exception('Cannot find archive file.');
@@ -73,7 +73,7 @@ class XMLReader
      * @param string $content
      * @return \DOMDocument
      */
-    public function getDomFromString($content)
+    public function getDomFromString(string $content): \DOMDocument
     {
         $this->dom = new \DOMDocument();
         $this->dom->loadXML($content);
@@ -88,7 +88,7 @@ class XMLReader
      * @param \DOMNode $contextNode
      * @return \DOMNodeList|array
      */
-    public function getElements($path, ?\DOMNode $contextNode = null)
+    public function getElements(string $path, ?\DOMNode $contextNode = null)
     {
         if ($this->dom === null) {
             return array();
@@ -107,7 +107,7 @@ class XMLReader
      * @param \DOMNode|null $contextNode
      * @return \DOMElement|null
      */
-    public function getElement($path, ?\DOMNode $contextNode = null)
+    public function getElement(string $path, ?\DOMNode $contextNode = null): ?\DOMElement
     {
         $elements = $this->getElements($path, $contextNode);
         $item = $elements->item(0);
@@ -125,7 +125,7 @@ class XMLReader
      * @param string $path
      * @return string|null
      */
-    public function getAttribute($attribute, ?\DOMElement $contextNode = null, $path = null)
+    public function getAttribute(string $attribute, ?\DOMElement $contextNode = null, ?string $path = null): ?string
     {
         $return = null;
         if ($path !== null) {
@@ -151,7 +151,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return string|null
      */
-    public function getValue($path, ?\DOMElement $contextNode = null)
+    public function getValue(string $path, ?\DOMElement $contextNode = null): ?string
     {
         $elements = $this->getElements($path, $contextNode);
         if ($elements->length > 0) {
@@ -168,7 +168,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return integer
      */
-    public function countElements($path, ?\DOMElement $contextNode = null)
+    public function countElements(string $path, ?\DOMElement $contextNode = null): int
     {
         $elements = $this->getElements($path, $contextNode);
 
@@ -182,7 +182,7 @@ class XMLReader
      * @param \DOMElement $contextNode
      * @return boolean
      */
-    public function elementExists($path, ?\DOMElement $contextNode = null)
+    public function elementExists(string $path, ?\DOMElement $contextNode = null): bool
     {
         return $this->getElements($path, $contextNode)->length > 0;
     }

--- a/src/PhpProject/Shared/XMLWriter.php
+++ b/src/PhpProject/Shared/XMLWriter.php
@@ -63,7 +63,7 @@ class XMLWriter
      * @param int $pTemporaryStorage Temporary storage location
      * @param string $pTemporaryStorageDir Temporary storage folder
      */
-    public function __construct($pTemporaryStorage = self::STORAGE_MEMORY, $pTemporaryStorageDir = './')
+    public function __construct(int $pTemporaryStorage = self::STORAGE_MEMORY, string $pTemporaryStorageDir = './')
     {
         // Create internal XMLWriter
         $this->xmlWriter = new \XMLWriter();
@@ -100,10 +100,10 @@ class XMLWriter
     /**
      * Catch function calls (and pass them to internal XMLWriter)
      *
-     * @param mixed $function
-     * @param mixed $args
+     * @param string $function
+     * @param array $args
      */
-    public function __call($function, $args)
+    public function __call(string $function, array $args)
     {
         try {
             @call_user_func_array(array(
@@ -120,7 +120,7 @@ class XMLWriter
      *
      * @return string
      */
-    public function getData()
+    public function getData(): string
     {
         if ($this->tempFileName == '') {
             return $this->xmlWriter->outputMemory(true);

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -166,6 +166,9 @@ class Task
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
 
@@ -198,6 +201,9 @@ class Task
                 $pValue = intval($pValue);
             } else {
                 $pValue = strtotime($pValue);
+                if ($pValue === false) {
+                    $pValue = null;
+                }
             }
         }
 

--- a/src/PhpProject/Task.php
+++ b/src/PhpProject/Task.php
@@ -34,8 +34,8 @@ class Task
      * 
      * @var string
      */
-    private $name;
-    
+    private $name = '';
+
     /**
      * Duration
      * 
@@ -102,7 +102,7 @@ class Task
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -113,7 +113,7 @@ class Task
      * @param string $pValue Name of the task
      * @return self
      */
-    public function setName($pValue)
+    public function setName(string $pValue): self
     {
         $this->name = $pValue;
         return $this;
@@ -135,7 +135,7 @@ class Task
      * @param int|float|string $pValue Duration of the resource
      * @return self
      */
-    public function setDuration($pValue)
+    public function setDuration($pValue): self
     {
         $this->duration = $pValue;
         return $this;
@@ -146,7 +146,7 @@ class Task
      *
      * @return int|null
      */
-    public function getStartDate()
+    public function getStartDate(): ?int
     {
         return $this->startDate;
     }
@@ -157,7 +157,7 @@ class Task
      * @param int|string|null $pValue
      * @return self
      */
-    public function setStartDate($pValue = null)
+    public function setStartDate($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();
@@ -178,7 +178,7 @@ class Task
      *
      * @return int|null
      */
-    public function getEndDate()
+    public function getEndDate(): ?int
     {
         return $this->endDate;
     }
@@ -189,7 +189,7 @@ class Task
      * @param int|string|null $pValue
      * @return self
      */
-    public function setEndDate($pValue = null)
+    public function setEndDate($pValue = null): self
     {
         if ($pValue === null) {
             $pValue = time();
@@ -210,7 +210,7 @@ class Task
      *
      * @return float|null
      */
-    public function getProgress()
+    public function getProgress(): ?float
     {
         return $this->progress;
     }
@@ -221,7 +221,7 @@ class Task
      * @param int|float|string $pValue Progress of the task
      * @return self
      */
-    public function setProgress($pValue = 0)
+    public function setProgress($pValue = 0): self
     {
         if (!is_numeric($pValue)) {
             $this->progress = 0;
@@ -240,7 +240,7 @@ class Task
     /**
      * Get index
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
@@ -249,7 +249,7 @@ class Task
      * Set index
      * @param int|string $value
      */
-    public function setIndex($value)
+    public function setIndex($value): self
     {
         if (is_numeric($value)) {
             $this->index = (int)$value;
@@ -264,7 +264,7 @@ class Task
      * Add a resource used by the current task
      * @param Resource $oResource
      */
-    public function addResource(Resource $oResource)
+    public function addResource(Resource $oResource): self
     {
         if (!in_array($oResource, $this->resourceCollection)) {
             $this->resourceCollection[] = &$oResource;
@@ -277,12 +277,12 @@ class Task
      * 
      * @return Resource[]
      */
-    public function getResources()
+    public function getResources(): array
     {
         return $this->resourceCollection;
     }
 
-    public function getResourceCount()
+    public function getResourceCount(): int
     {
         return count($this->resourceCollection);
     }
@@ -290,7 +290,7 @@ class Task
     //===============================================
     // Tasks
     //===============================================
-    public function createTask()
+    public function createTask(): self
     {
         $newTask = new self();
         $this->taskCollection[] = $newTask;
@@ -302,12 +302,12 @@ class Task
      *
      * @return self[]
      */
-    public function getTasks()
+    public function getTasks(): array
     {
         return $this->taskCollection;
     }
 
-    public function getTaskCount()
+    public function getTaskCount(): int
     {
         return count($this->taskCollection);
     }


### PR DESCRIPTION
Adds parameter and return types to all source classes except
`Reader/` and `Writer/` (separate PR to come): `Resource`, `DocumentInformations`,
`DocumentProperties`, `IOFactory`, `PhpProject`, `Task`, `Shared\XMLReader`,
`Shared\XMLWriter`.

