### PR TITLE
Type method signatures of Reader and Writer classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
+- Typed method signatures of `Reader` and `Writer` classes (`ReaderInterface`, `WriterInterface`, `Reader\GanttProject`, `Reader\MsProjectMPX`, `Writer\GanttProject`, `Writer\MsProjectMPX`) - @slayerfx GH-46
 - Typed method signatures of core classes (`Resource`, `DocumentInformations`, `DocumentProperties`, `IOFactory`, `PhpProject`, `Task`, `Shared\XMLReader`, `Shared\XMLWriter`) - `setIndex` parameter intentionally untyped, union type `int|string` not available in PHP 7.3 - @slayerfx GH-45
 - Added `declare(strict_types=1);` to all source files (no behaviour change, sets foundation for strict signature typing) - @slayerfx GH-44
 - Removed manual `Autoloader.php` in favor of Composer autoloader (samples, tests bootstrap, README and docs updated) - @slayerfx GH-43

--- a/src/PhpProject/Reader/GanttProject.php
+++ b/src/PhpProject/Reader/GanttProject.php
@@ -53,7 +53,7 @@ class GanttProject implements ReaderInterface
      * @param string $pFilename
      * @return bool
      */
-    public function canRead($pFilename)
+    public function canRead(string $pFilename): bool
     {
         if (file_exists($pFilename) && is_readable($pFilename)) {
             return true;
@@ -67,7 +67,7 @@ class GanttProject implements ReaderInterface
      * @throws \Exception
      * @return PHPProject
      */
-    public function load($pFilename)
+    public function load(string $pFilename): PhpProject
     {
         if (!file_exists($pFilename) || !is_readable($pFilename)) {
             throw new \Exception('The file is not accessible.');
@@ -103,7 +103,7 @@ class GanttProject implements ReaderInterface
      * Node "Description"
      * @param \DOMElement $domNode
      */
-    private function readNodeDescription(\DOMElement $domNode)
+    private function readNodeDescription(\DOMElement $domNode): void
     {
         $this->phpProject->getProperties()->setDescription($domNode->nodeValue);
     }
@@ -113,7 +113,7 @@ class GanttProject implements ReaderInterface
      * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
-    private function readNodeTasks(XMLReader $oXML, \DOMElement $domNode)
+    private function readNodeTasks(XMLReader $oXML, \DOMElement $domNode): void
     {
         $oNodes = $oXML->getElements('*', $domNode);
         if ($oNodes->length > 0) {
@@ -131,7 +131,7 @@ class GanttProject implements ReaderInterface
      * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
-    private function readNodeTask(XMLReader $oXML, \DOMElement $domNode, Task $oTask)
+    private function readNodeTask(XMLReader $oXML, \DOMElement $domNode, Task $oTask): void
     {
         // Attributes
         $oTask->setIndex($domNode->getAttribute('id'));
@@ -157,7 +157,7 @@ class GanttProject implements ReaderInterface
      * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
-    private function readNodeResources(XMLReader $oXML, \DOMElement $domNode)
+    private function readNodeResources(XMLReader $oXML, \DOMElement $domNode): void
     {
         $oNodes = $oXML->getElements('*', $domNode);
         if ($oNodes->length > 0) {
@@ -174,7 +174,7 @@ class GanttProject implements ReaderInterface
      * @param \DOMElement $domNode
      * @param Resource $oResource
      */
-    private function readNodeResource(\DOMElement $domNode, Resource $oResource)
+    private function readNodeResource(\DOMElement $domNode, Resource $oResource): void
     {
         // Attributes
         $oResource->setIndex($domNode->getAttribute('id'));
@@ -186,7 +186,7 @@ class GanttProject implements ReaderInterface
      * @param XMLReader $oXML
      * @param \DOMElement $domNode
      */
-    private function readNodeAllocations(XMLReader $oXML, \DOMElement $domNode)
+    private function readNodeAllocations(XMLReader $oXML, \DOMElement $domNode): void
     {
         $oNodes = $oXML->getElements('*', $domNode);
         if ($oNodes->length > 0) {
@@ -201,7 +201,7 @@ class GanttProject implements ReaderInterface
      * Node "Allocation"
      * @param \DOMElement $domNode
      */
-    private function readNodeAllocation(\DOMElement $domNode)
+    private function readNodeAllocation(\DOMElement $domNode): void
     {
         // Attributes
         $idTask = $domNode->getAttribute('task-id');

--- a/src/PhpProject/Reader/MsProjectMPX.php
+++ b/src/PhpProject/Reader/MsProjectMPX.php
@@ -75,7 +75,7 @@ class MsProjectMPX implements ReaderInterface
      * @param string $pFilename
      * @return bool
      */
-    public function canRead($pFilename)
+    public function canRead(string $pFilename): bool
     {
         if (!file_exists($pFilename) || !is_readable($pFilename)) {
             return false;
@@ -98,9 +98,9 @@ class MsProjectMPX implements ReaderInterface
      * 
      * @param string $pFilename
      * @throws \Exception
-     * @return PHPProject|null
+     * @return PhpProject
      */
-    public function load($pFilename)
+    public function load(string $pFilename): PhpProject
     {
         if (!$this->canRead($pFilename)) {
             throw new \Exception('The file is not accessible.');
@@ -167,7 +167,7 @@ class MsProjectMPX implements ReaderInterface
      * Project Header
      * @param array $record
      */
-    private function readRecord30(array $record)
+    private function readRecord30(array $record): void
     {
         // 0 : Record
         // 1 : Project tab
@@ -211,7 +211,7 @@ class MsProjectMPX implements ReaderInterface
      * Numeric Resource Table Definition
      * @param array $record
      */
-    private function readRecord41(array $record)
+    private function readRecord41(array $record): void
     {
         array_shift($record);
         foreach ($record as $key => $item) {
@@ -236,7 +236,7 @@ class MsProjectMPX implements ReaderInterface
      * Resource
      * @param array $record
      */
-    private function readRecord50(array $record)
+    private function readRecord50(array $record): void
     {
         $oResource = $this->phpProject->createResource();
         
@@ -249,7 +249,7 @@ class MsProjectMPX implements ReaderInterface
      * Numeric Task Table Definition
      * @param array $record
      */
-    private function readRecord61(array $record)
+    private function readRecord61(array $record): void
     {
         array_shift($record);
         foreach ($record as $key => $item) {
@@ -298,7 +298,7 @@ class MsProjectMPX implements ReaderInterface
      * Task
      * @param array $record
      */
-    private function readRecord70(array $record)
+    private function readRecord70(array $record): void
     {
         $oTask = null;
         if (!is_null($this->iParentTaskIdx) && !empty($record[$this->iParentTaskIdx])) {
@@ -333,7 +333,7 @@ class MsProjectMPX implements ReaderInterface
      * Resource Assignment
      * @param array $record
      */
-    private function readRecord75(array $record)
+    private function readRecord75(array $record): void
     {
         // 0 : Record
         // 1 : ID

--- a/src/PhpProject/Reader/ReaderInterface.php
+++ b/src/PhpProject/Reader/ReaderInterface.php
@@ -12,7 +12,7 @@ interface ReaderInterface
      * @param  string $pFilename
      * @return bool
      */
-    public function canRead($pFilename);
+    public function canRead(string $pFilename): bool;
 
     /**
      * Loads PHPProject from file
@@ -20,5 +20,5 @@ interface ReaderInterface
      * @param  string $pFilename
      * @return \PhpOffice\PhpProject\PhpProject
      */
-    public function load($pFilename);
+    public function load(string $pFilename): \PhpOffice\PhpProject\PhpProject;
 }

--- a/src/PhpProject/Writer/GanttProject.php
+++ b/src/PhpProject/Writer/GanttProject.php
@@ -63,7 +63,7 @@ class GanttProject implements WriterInterface
      * @param string $pFilename
      * @throws \Exception
      */
-    public function save($pFilename)
+    public function save(string $pFilename): void
     {
         $arrProjectInfo = $this->sanitizeProject();
         
@@ -311,7 +311,7 @@ class GanttProject implements WriterInterface
         fclose($fileHandle);
     }
     
-    private function writeTask(XMLWriter $oXML, Task $oTask)
+    private function writeTask(XMLWriter $oXML, Task $oTask): void
     {
         $oXML->startElement('task');
         $oXML->writeAttribute('id', $oTask->getIndex());
@@ -349,7 +349,7 @@ class GanttProject implements WriterInterface
      * @param XMLWriter $oXML
      * @param \PhpOffice\PhpProject\Resource $oResource
      */
-    private function writeResource(XMLWriter $oXML, \PhpOffice\PhpProject\Resource $oResource)
+    private function writeResource(XMLWriter $oXML, \PhpOffice\PhpProject\Resource $oResource): void
     {
         $oXML->startElement('resource');
         $oXML->writeAttribute('id', $oResource->getIndex());
@@ -366,7 +366,7 @@ class GanttProject implements WriterInterface
      * @param integer $piIdTask
      * @param integer $piIdResource
      */
-    private function writeAllocation(XMLWriter $oXML, $piIdTask, $piIdResource)
+    private function writeAllocation(XMLWriter $oXML, int $piIdTask, int $piIdResource): void
     {
         $oXML->startElement('allocation');
         $oXML->writeAttribute('task-id', $piIdTask);
@@ -380,7 +380,7 @@ class GanttProject implements WriterInterface
     /**
      * @return array
      */
-    private function sanitizeProject()
+    private function sanitizeProject(): array
     {
         // Info Project
         $minDate = 0;
@@ -409,7 +409,7 @@ class GanttProject implements WriterInterface
      * - If the end date is not filled, but the duration is, we calculate it.
      * @param Task $oTask
      */
-    private function sanitizeTask(Task $oTask)
+    private function sanitizeTask(Task $oTask): void
     {
         $pDuration = $oTask->getDuration();
         $pEndDate = $oTask->getEndDate();
@@ -429,7 +429,7 @@ class GanttProject implements WriterInterface
      *   date start and complete average.
      * @param Task $oParentTask
      */
-    private function sanitizeTaskParent(Task $oParentTask)
+    private function sanitizeTaskParent(Task $oParentTask): void
     {
         $arrTasksChilds = $oParentTask->getTasks();
         

--- a/src/PhpProject/Writer/MsProjectMPX.php
+++ b/src/PhpProject/Writer/MsProjectMPX.php
@@ -62,7 +62,7 @@ class MsProjectMPX implements WriterInterface
      * @param string $pFilename
      * @throws \Exception
      */
-    public function save($pFilename)
+    public function save(string $pFilename): void
     {
         $arrProjectInfo = $this->sanitizeProject();
         
@@ -101,7 +101,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * @return array
      */
-    private function sanitizeProject()
+    private function sanitizeProject(): array
     {
         // Info Project
         $minDate = 0;
@@ -130,7 +130,7 @@ class MsProjectMPX implements WriterInterface
      * - If the end date is not filled, but the duration is, we calculate it.
      * @param Task $oTask
      */
-    private function sanitizeTask(Task $oTask)
+    private function sanitizeTask(Task $oTask): void
     {
         $pDuration = $oTask->getDuration();
         $pEndDate = $oTask->getEndDate();
@@ -150,7 +150,7 @@ class MsProjectMPX implements WriterInterface
      *   date start and complete average.
      * @param Task $oParentTask
      */
-    private function sanitizeTaskParent(Task $oParentTask)
+    private function sanitizeTaskParent(Task $oParentTask): void
     {
         $arrTasksChilds = $oParentTask->getTasks();
         
@@ -186,7 +186,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record MPX
      */
-    private function writeRecordMPX()
+    private function writeRecordMPX(): void
     {
         $this->fileContent[] = 'MPX;Microsoft Project for Windows;4.0;ANSI';
     }
@@ -194,7 +194,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record "Project Header"
      */
-    private function writeRecord30(array $arrProjectInfo)
+    private function writeRecord30(array $arrProjectInfo): void
     {
         $this->fileContent[] = '30;Project1;;;Standard;'.date('d/m/Y', $arrProjectInfo['date_start']).';;0;'.date('d/m/Y').';;$0,00;$0,00;$0,00;0h;0h;0h;0%;0d;0d;0d;0%;;;;;0d;0d';
     }
@@ -202,7 +202,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record "Text Resource Table Definition"
      */
-    private function writeRecord40()
+    private function writeRecord40(): void
     {
         $this->fileContent[] = '40;ID;Name';
     }
@@ -210,7 +210,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record "Numeric Resource Table Definition"
      */
-    private function writeRecord41()
+    private function writeRecord41(): void
     {
         $this->fileContent[] = '41;40;1';
     }
@@ -219,7 +219,7 @@ class MsProjectMPX implements WriterInterface
      * Record "Resource"
      * @param Resource $oResource
      */
-    private function writeRecord50(Resource $oResource)
+    private function writeRecord50(Resource $oResource): void
     {
         $this->fileContent[] = '50;'.$oResource->getIndex().';'.$oResource->getTitle();
     }
@@ -227,7 +227,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record "Text Task Table Definition"
      */
-    private function writeRecord60()
+    private function writeRecord60(): void
     {
         $this->fileContent[] = '60;ID;Name;Duration;% Complete;Start';
     }
@@ -235,7 +235,7 @@ class MsProjectMPX implements WriterInterface
     /**
      * Record "Numeric Task Table Definition"
      */
-    private function writeRecord61()
+    private function writeRecord61(): void
     {
         $this->fileContent[] = '61;90;1;40;44;50';
     }
@@ -244,7 +244,7 @@ class MsProjectMPX implements WriterInterface
      * Record "Task"
      * @param Task $oTask
      */
-    private function writeRecord70(Task $oTask)
+    private function writeRecord70(Task $oTask): void
     {
         $this->fileContent[] = '70;'.$oTask->getIndex().';'.$oTask->getName().';'.$oTask->getDuration().'d;'.number_format($oTask->getProgress() ?? 0, 1).';'.date('d/m/Y', $oTask->getStartDate() ?? time());
         
@@ -261,7 +261,7 @@ class MsProjectMPX implements WriterInterface
      * Record "Resource Assignment"
      * @param Resource $oResource
      */
-    private function writeRecord75(Resource $oResource)
+    private function writeRecord75(Resource $oResource): void
     {
         $this->fileContent[] = '75;'.$oResource->getIndex().';1;;;;;;;;;;;';
     }

--- a/src/PhpProject/Writer/WriterInterface.php
+++ b/src/PhpProject/Writer/WriterInterface.php
@@ -12,5 +12,5 @@ interface WriterInterface
      * @param  string $pFilename
      * @return void
      */
-    public function save($pFilename);
+    public function save(string $pFilename): void;
 }


### PR DESCRIPTION
Adds parameter and return types to the `Reader/` and `Writer/` classes, completing the strict signature typing:
`ReaderInterface`, `WriterInterface`, `Reader\GanttProject`, `Reader\MsProjectMPX`,
`Writer\GanttProject`, `Writer\MsProjectMPX`.