### PR TITLE
Bump phpstan analysis level from 5 to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
+- Bumped phpstan analysis level from 5 to 6 - @slayerfx GH-50
+- Added missing return types, parameter types and array value types for phpstan level 6 across source and test files - @slayerfx GH-50
 - Updated documented minimum PHP version to 7.3 in README and docs (was 5.3; already enforced in `composer.json`) - @slayerfx GH-49
 - Removed obsolete `.scrutinizer.yml` (Scrutinizer received coverage via Travis, removed during the GitHub Actions migration; badges already replaced by Coveralls) - @slayerfx GH-48
 - Migrated documentation build from MkDocs to ProperDocs (maintained drop-in fork; renamed `mkdocs.yml` to `properdocs.yml`) - @slayerfx GH-47

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 6
   bootstrapFiles:
     - tests/bootstrap.php
   paths:

--- a/src/PhpProject/DocumentProperties.php
+++ b/src/PhpProject/DocumentProperties.php
@@ -480,6 +480,9 @@ class DocumentProperties
         return $this;
     }
 
+    /**
+     * @return mixed
+     */
     public static function convertProperty(string $propertyValue, string $propertyType)
     {
         switch ($propertyType) {

--- a/src/PhpProject/IOFactory.php
+++ b/src/PhpProject/IOFactory.php
@@ -28,7 +28,7 @@ class IOFactory
     /**
      * Autoresolve classes
      *
-     * @var array
+     * @var string[]
      */
     private static $autoResolveClasses = array('GanttProject');
 

--- a/src/PhpProject/PhpProject.php
+++ b/src/PhpProject/PhpProject.php
@@ -168,6 +168,7 @@ class PhpProject
     /**
      * Get resource from index
      *
+     * @param int|string $pIndex
      * @return Resource|null
      */
     public function getResourceFromIndex($pIndex): ?Resource
@@ -232,6 +233,7 @@ class PhpProject
     /**
      * Get task from index
      *
+     * @param int|string $pIndex
      * @return Task|null
      */
     public function getTaskFromIndex($pIndex, ?Task $oTaskParent = null): ?Task

--- a/src/PhpProject/Reader/MsProjectMPX.php
+++ b/src/PhpProject/Reader/MsProjectMPX.php
@@ -165,7 +165,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Project Header
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord30(array $record): void
     {
@@ -209,7 +209,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Numeric Resource Table Definition
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord41(array $record): void
     {
@@ -234,7 +234,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Resource
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord50(array $record): void
     {
@@ -247,7 +247,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Numeric Task Table Definition
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord61(array $record): void
     {
@@ -296,7 +296,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Task
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord70(array $record): void
     {
@@ -331,7 +331,7 @@ class MsProjectMPX implements ReaderInterface
     
     /**
      * Resource Assignment
-     * @param array $record
+     * @param string[] $record
      */
     private function readRecord75(array $record): void
     {

--- a/src/PhpProject/Shared/XMLReader.php
+++ b/src/PhpProject/Shared/XMLReader.php
@@ -86,7 +86,7 @@ class XMLReader
      *
      * @param string $path
      * @param \DOMNode $contextNode
-     * @return \DOMNodeList|array
+     * @return \DOMNodeList<\DOMElement>|array<\DOMElement>
      */
     public function getElements(string $path, ?\DOMNode $contextNode = null)
     {

--- a/src/PhpProject/Shared/XMLWriter.php
+++ b/src/PhpProject/Shared/XMLWriter.php
@@ -101,9 +101,9 @@ class XMLWriter
      * Catch function calls (and pass them to internal XMLWriter)
      *
      * @param string $function
-     * @param array $args
+     * @param mixed[] $args
      */
-    public function __call(string $function, array $args)
+    public function __call(string $function, array $args): void
     {
         try {
             @call_user_func_array(array(

--- a/src/PhpProject/Writer/GanttProject.php
+++ b/src/PhpProject/Writer/GanttProject.php
@@ -41,8 +41,8 @@ class GanttProject implements WriterInterface
     private $phpProject;
     
     /**
-     * 
-     * @var array
+     *
+     * @var array<array{id_res: int, id_task: int}>
      */
     private $arrAllocations;
     
@@ -72,7 +72,7 @@ class GanttProject implements WriterInterface
         $oXML->startDocument('1.0', 'UTF-8');
         // project
         $oXML->startElement('project');
-        if (isset($arrProjectInfo['date_start']) && $arrProjectInfo['date_start'] != 0) {
+        if ($arrProjectInfo['date_start'] != 0) {
             $oXML->writeAttribute('view-date', date('Y-m-d', $arrProjectInfo['date_start']));
         }
         $oXML->writeAttribute('version', '2.0');
@@ -378,7 +378,7 @@ class GanttProject implements WriterInterface
     }
     
     /**
-     * @return array
+     * @return array{date_start: int}
      */
     private function sanitizeProject(): array
     {

--- a/src/PhpProject/Writer/MsProjectMPX.php
+++ b/src/PhpProject/Writer/MsProjectMPX.php
@@ -99,7 +99,7 @@ class MsProjectMPX implements WriterInterface
     }
     
     /**
-     * @return array
+     * @return array{date_start: int}
      */
     private function sanitizeProject(): array
     {
@@ -193,6 +193,7 @@ class MsProjectMPX implements WriterInterface
     
     /**
      * Record "Project Header"
+     * @param array{date_start: int} $arrProjectInfo
      */
     private function writeRecord30(array $arrProjectInfo): void
     {

--- a/tests/PhpProject/Tests/DocumentInformationsTest.php
+++ b/tests/PhpProject/Tests/DocumentInformationsTest.php
@@ -25,14 +25,14 @@ use PhpOffice\PhpProject\PhpProject;
  */
 class DocumentInformationsTest extends \PHPUnit\Framework\TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $object = new DocumentInformations();
         $this->assertEmpty($object->getStartDate());
         $this->assertEmpty($object->getEndDate());
     }
     
-    public function testEndDate()
+    public function testEndDate(): void
     {
         $value = time();
         
@@ -45,7 +45,7 @@ class DocumentInformationsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(strtotime('2014-08-05 19:30:00'), $object->getEndDate());
     }
     
-    public function testStartDate()
+    public function testStartDate(): void
     {
         $value = time();
         

--- a/tests/PhpProject/Tests/DocumentPropertiesTest.php
+++ b/tests/PhpProject/Tests/DocumentPropertiesTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpProject\PhpProject;
  */
 class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCustomProperties()
+    public function testCustomProperties(): void
     {
         $object = new DocumentProperties();
         $this->assertIsArray($object->getCustomProperties());
@@ -89,7 +89,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAAValue', $object->getCustomPropertyValue('AAAName1'));
     }
     
-    public function testCustomPropertiesConvertProperty()
+    public function testCustomPropertiesConvertProperty(): void
     {
         $object = new DocumentProperties();
         $this->assertEmpty($object->convertProperty('AAA', 'empty'));
@@ -127,7 +127,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('3.5', $object->convertProperty('3.5', 'cf'));
     }
     
-    public function testCustomPropertiesConvertPropertyType()
+    public function testCustomPropertiesConvertPropertyType(): void
     {
         $object = new DocumentProperties();
         $this->assertEquals(DocumentProperties::PROPERTY_TYPE_INTEGER, $object->convertPropertyType('i1'));
@@ -165,7 +165,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(DocumentProperties::PROPERTY_TYPE_UNKNOWN, $object->convertPropertyType('TypeNotExists'));
     }
     
-    public function testGetSetCategory()
+    public function testGetSetCategory(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCategory());
@@ -174,7 +174,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getCategory());
     }
     
-    public function testGetSetCompany()
+    public function testGetSetCompany(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCompany());
@@ -183,7 +183,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getCompany());
     }
     
-    public function testGetSetCreated()
+    public function testGetSetCreated(): void
     {
         $value = time();
     
@@ -196,7 +196,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(strtotime('2014-08-05 19:30:00'), $object->getCreated());
     }
     
-    public function testGetSetCreator()
+    public function testGetSetCreator(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCreator());
@@ -205,7 +205,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getCreator());
     }
     
-    public function testGetSetDescription()
+    public function testGetSetDescription(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setDescription());
@@ -214,7 +214,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getDescription());
     }
     
-    public function testGetSetKeywords()
+    public function testGetSetKeywords(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setKeywords());
@@ -223,7 +223,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getKeywords());
     }
     
-    public function testGetSetLastModifiedBy()
+    public function testGetSetLastModifiedBy(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setLastModifiedBy());
@@ -232,7 +232,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getLastModifiedBy());
     }
 
-    public function testGetSetManager()
+    public function testGetSetManager(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setManager());
@@ -241,7 +241,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getManager());
     }
     
-    public function testGetSetModified()
+    public function testGetSetModified(): void
     {
         $value = time();
     
@@ -254,7 +254,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(strtotime('2014-08-05 19:30:00'), $object->getModified());
     }
     
-    public function testGetSetSubject()
+    public function testGetSetSubject(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setSubject());
@@ -263,7 +263,7 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getSubject());
     }
     
-    public function testGetSetTitle()
+    public function testGetSetTitle(): void
     {
         $object = new DocumentProperties();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setTitle());

--- a/tests/PhpProject/Tests/IOFactoryTest.php
+++ b/tests/PhpProject/Tests/IOFactoryTest.php
@@ -25,33 +25,33 @@ use PhpOffice\PhpProject\PhpProject;
  */
 class IOFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    public function testLoad()
+    public function testLoad(): void
     {
         $file = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_01_Simple.gan';
         $this->assertInstanceOf('PhpOffice\\PhpProject\\PhpProject', IOFactory::load($file));
     }    
     
-    public function testLoadFileNotExists()
+    public function testLoadFileNotExists(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Could not automatically determine \PhpOffice\PhpProject\Reader\ReaderInterface for file.");
         IOFactory::load('fileNotExists');
     }
     
-    public function testReader()
+    public function testReader(): void
     {
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Reader\\GanttProject', IOFactory::createReader());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Reader\\GanttProject', IOFactory::createReader('GanttProject'));
     }    
     
-    public function testReaderException()
+    public function testReaderException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("\"ReaderNotExists\" is not a valid reader.");
         IOFactory::createReader('ReaderNotExists');
     }
     
-    public function testWriter()
+    public function testWriter(): void
     {
         $object = new PhpProject();
     
@@ -59,7 +59,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Writer\\GanttProject', IOFactory::createWriter($object, 'GanttProject'));
     }    
     
-    public function testWriterException()
+    public function testWriterException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("\"WriterNotExists\" is not a valid writer.");

--- a/tests/PhpProject/Tests/PhpProjectTest.php
+++ b/tests/PhpProject/Tests/PhpProjectTest.php
@@ -29,7 +29,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
     /**
      * Register
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $object = new PhpProject();
 
@@ -37,7 +37,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->getInformations());
     }
     
-    public function testGetSetInformations()
+    public function testGetSetInformations(): void
     {
         $object = new PhpProject();
         $oInformations = new DocumentInformations();
@@ -47,7 +47,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->getInformations());
     }
     
-    public function testGetSetProperties()
+    public function testGetSetProperties(): void
     {
         $object = new PhpProject();
         $oProperties = new DocumentProperties();
@@ -57,7 +57,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->getProperties());
     }
     
-    public function testResource()
+    public function testResource(): void
     {
         $object = new PhpProject();
 
@@ -74,7 +74,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Resource', $object->getActiveResource());
     }
     
-    public function testResourceFromIndex()
+    public function testResourceFromIndex(): void
     {
         $object = new PhpProject();
         $oResource1 = $object->createResource();
@@ -86,7 +86,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($object->getResourceFromIndex(1));
     }
     
-    public function testTask()
+    public function testTask(): void
     {
         $object = new PhpProject();
     
@@ -115,7 +115,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->getActiveTask());
     }
     
-    public function testTaskFromIndex()
+    public function testTaskFromIndex(): void
     {
         $object = new PhpProject();
         $oTask1 = $object->createTask();
@@ -129,7 +129,7 @@ class PhpProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($object->getTaskFromIndex(1));
     }    
     
-    public function testTaskRemoveException()
+    public function testTaskRemoveException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Task index is out of bounds.");        

--- a/tests/PhpProject/Tests/Reader/GanttProjectTest.php
+++ b/tests/PhpProject/Tests/Reader/GanttProjectTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpProject\Reader\GanttProject;
  */
 class GanttProjectTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCanRead()
+    public function testCanRead(): void
     {
         $file = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_02.gan';
         $file404 = 'fileError';
@@ -37,7 +37,7 @@ class GanttProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($object->canRead($file404));
     }
     
-    public function testLoad()
+    public function testLoad(): void
     {
         $file = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_02.gan';
         $object = new GanttProject();
@@ -48,7 +48,7 @@ class GanttProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, $return->getTaskCount());
     }    
     
-    public function testLoadException()
+    public function testLoadException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("The file is not accessible.");  

--- a/tests/PhpProject/Tests/Reader/MsProjectMPXTest.php
+++ b/tests/PhpProject/Tests/Reader/MsProjectMPXTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpProject\Reader\MsProjectMPX;
  */
 class MsProjectMPXTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCanRead()
+    public function testCanRead(): void
     {
         $fileMPX = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_02.mpx';
         $fileGAN = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_02.gan';
@@ -39,7 +39,7 @@ class MsProjectMPXTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($object->canRead($file404));
     }
     
-    public function testLoad()
+    public function testLoad(): void
     {
         $file = PHPPROJECT_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'PhpProject'.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'Sample_02.mpx';
         $object = new MsProjectMPX();
@@ -50,7 +50,7 @@ class MsProjectMPXTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, $return->getTaskCount());
     }    
     
-    public function testLoadException()
+    public function testLoadException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("The file is not accessible.");  

--- a/tests/PhpProject/Tests/ResourceTest.php
+++ b/tests/PhpProject/Tests/ResourceTest.php
@@ -28,7 +28,7 @@ class ResourceTest extends \PHPUnit\Framework\TestCase
     /**
      * Register
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $object = new Resource();
         
@@ -36,7 +36,7 @@ class ResourceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, $object->getIndex());
     }
     
-    public function testGetSetIndex()
+    public function testGetSetIndex(): void
     {
         $object = new Resource();
     
@@ -49,7 +49,7 @@ class ResourceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, $object->getIndex());
     }
     
-    public function testGetSetTitle()
+    public function testGetSetTitle(): void
     {
         $object = new Resource();
     

--- a/tests/PhpProject/Tests/Shared/XMLReaderTest.php
+++ b/tests/PhpProject/Tests/Shared/XMLReaderTest.php
@@ -27,7 +27,7 @@ use PhpOffice\PhpProject\Shared\XMLReader;
  */
 class XMLReaderTest extends \PHPUnit\Framework\TestCase
 { 
-    public function testGetDomFromZipException()
+    public function testGetDomFromZipException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Cannot find archive file.");  
@@ -39,7 +39,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get DOMDocument from ZipArchive returns false
      */
-    public function testGetDomFromZipReturnsFalse()
+    public function testGetDomFromZipReturnsFalse(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -49,7 +49,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get element
      */
-    public function testGetElement()
+    public function testGetElement(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -60,7 +60,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get elements returns empty
      */
-    public function testGetElementsReturnsEmpty()
+    public function testGetElementsReturnsEmpty(): void
     {
         $object = new XMLReader();
         $this->assertEquals(array(), $object->getElements('w:document'));
@@ -69,7 +69,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get element returns null
      */
-    public function testGetElementReturnsNull()
+    public function testGetElementReturnsNull(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
 
@@ -83,7 +83,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get attribute
      */
-    public function testGetAttribute()
+    public function testGetAttribute(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -95,7 +95,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get attribute
      */
-    public function testGetAttributeWithPath()
+    public function testGetAttributeWithPath(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -107,7 +107,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get attribute
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -118,7 +118,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test get attribute
      */
-    public function testGetValueNull()
+    public function testGetValueNull(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -129,7 +129,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test count Elements
      */
-    public function testCountElements()
+    public function testCountElements(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();
@@ -140,7 +140,7 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test count Elements
      */
-    public function testElementExists()
+    public function testElementExists(): void
     {
         $filename = __DIR__ . "/../../resources/reader.docx.zip";
         $object = new XMLReader();

--- a/tests/PhpProject/Tests/Shared/XMLWriterTest.php
+++ b/tests/PhpProject/Tests/Shared/XMLWriterTest.php
@@ -28,7 +28,7 @@ class XMLWriterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         // Memory
         $object = new XMLWriter();

--- a/tests/PhpProject/Tests/TaskTest.php
+++ b/tests/PhpProject/Tests/TaskTest.php
@@ -29,7 +29,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
     /**
      * Register
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $object = new Task();
         
@@ -39,7 +39,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, $object->getResourceCount());
     }
     
-    public function testGetSetDuration()
+    public function testGetSetDuration(): void
     {
         $object = new Task();
         
@@ -50,7 +50,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($value, $object->getDuration());
     }
     
-    public function testGetSetEndDate()
+    public function testGetSetEndDate(): void
     {
         $object = new Task();
         
@@ -67,7 +67,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(strtotime('2014-12-05 00:05:00'), $object->getEndDate());
     }
     
-    public function testGetSetIndex()
+    public function testGetSetIndex(): void
     {
         $object = new Task();
     
@@ -80,7 +80,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, $object->getIndex());
     }
     
-    public function testGetSetName()
+    public function testGetSetName(): void
     {
         $object = new Task();
     
@@ -89,7 +89,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('AAA', $object->getName());
     }
     
-    public function testGetSetProgress()
+    public function testGetSetProgress(): void
     {
         $object = new Task();
     
@@ -104,7 +104,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0.5, $object->getProgress());
     }
     
-    public function testGetSetStartDate()
+    public function testGetSetStartDate(): void
     {
         $object = new Task();
         
@@ -121,7 +121,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(strtotime('2014-12-05 00:05:00'), $object->getStartDate());
     }
     
-    public function testResource()
+    public function testResource(): void
     {
         $object = new Task();
         $oResource = new Resource();
@@ -134,7 +134,7 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $object->getResourceCount());
     }
     
-    public function testTask()
+    public function testTask(): void
     {
         $object = new Task();
          

--- a/tests/PhpProject/Tests/Writer/GanttProjectTest.php
+++ b/tests/PhpProject/Tests/Writer/GanttProjectTest.php
@@ -30,7 +30,7 @@ use PhpOffice\PhpProject\Tests\XmlDocument;
  */
 class GanttProjectTest extends \PHPUnit\Framework\TestCase
 {
-    public function testSave()
+    public function testSave(): void
     {
         $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
         $oPHPProject = new PhpProject();
@@ -99,7 +99,7 @@ class GanttProjectTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($oXMLDocument->elementExists('/project/allocations/allocation[@task-id="0"][@resource-id="0"]', $fileOutput));
     }    
     
-    public function testSaveException()
+    public function testSaveException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Could not open file");

--- a/tests/PhpProject/Tests/Writer/MsProjectMPXTest.php
+++ b/tests/PhpProject/Tests/Writer/MsProjectMPXTest.php
@@ -28,7 +28,7 @@ use PhpOffice\PhpProject\Writer\MsProjectMPX;
  */
 class MsProjectMPXTest extends \PHPUnit\Framework\TestCase
 {
-    public function testSave()
+    public function testSave(): void
     {
         $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
         $oPHPProject = new PhpProject();
@@ -74,7 +74,7 @@ class MsProjectMPXTest extends \PHPUnit\Framework\TestCase
         }
     }    
     
-    public function testSaveException()
+    public function testSaveException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Could not open file");

--- a/tests/PhpProject/Tests/_includes/XmlDocument.php
+++ b/tests/PhpProject/Tests/_includes/XmlDocument.php
@@ -86,7 +86,7 @@ class XmlDocument
      *
      * @param string $path
      * @param string $file
-     * @return \DOMNodeList
+     * @return \DOMNodeList<\DOMNode>
      */
     public function getNodeList($path, $file = 'word/document.xml')
     {


### PR DESCRIPTION
- `src/`: added missing types - `@return mixed`, `@var string[]`, `@param int|string`, `@param string[]`, array shapes (`array{...}`), `XMLWriter::__call(): void`, generics on `getElements()`
- `tests/`: added `void` return type to 65 test methods + generic on `XmlDocument::getNodeList()`
- `phpstan.neon.dist`: `level: 5` → `6`
