### PR TITLE
Add MSPDI writer with resources (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
+- Added MSPDI (Microsoft Project Data Interchange) writer for `.xml` files (resources, tasks, and assignments) - @slayerfx GH-55
 - Added MSPDI (Microsoft Project Data Interchange) reader for `.xml` files (resources, tasks, and assignments) - @slayerfx GH-54
 - Added Gnome Planner writer for `.planner` files (resources, tasks with subtasks, and allocations) - @slayerfx GH-53
 - Added Gnome Planner reader for `.planner` files (resources, tasks with subtasks, and allocations) - @slayerfx GH-52

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ PhpProject is an open source project licensed under the terms of [LGPL version 3
 - Set file meta data (author, title, description, etc)
 - Add resources from scratch or from existing one
 - Add tasks from scratch or from existing one
-- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner)
+- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner), MSPDI (.xml)
 - ... and lots of other things!
 
 ## File formats
@@ -19,14 +19,14 @@ Below are the supported features for each file formats.
 
 ### Writers
 
-| Features                  |            | MPX | GAN | Planner |
-|---------------------------|------------|-----|-----|---------|
-| **Document Properties**   | Standard   |     |     |         |
-|                           | Custom     |     |     |         |
-| **Document Informations** |            |     |     |         |
-| **Project**               | Task       | ✓   | ✓   | ✓       |
-|                           | Resource   | ✓   | ✓   | ✓       |
-|                           | Allocation | ✓   | ✓   | ✓       |
+| Features                  |            | MPX | GAN | Planner | MSPDI |
+|---------------------------|------------|-----|-----|---------|-------|
+| **Document Properties**   | Standard   |     |     |         |       |
+|                           | Custom     |     |     |         |       |
+| **Document Informations** |            |     |     |         |       |
+| **Project**               | Task       | ✓   | ✓   | ✓       | ✓     |
+|                           | Resource   | ✓   | ✓   | ✓       | ✓     |
+|                           | Allocation | ✓   | ✓   | ✓       | ✓     |
 
 ### Readers
 

--- a/src/PhpProject/Writer/MSPDI.php
+++ b/src/PhpProject/Writer/MSPDI.php
@@ -38,6 +38,12 @@ class MSPDI implements WriterInterface
     protected $phpProject;
 
     /**
+     *
+     * @var array<array{id_res: int, id_task: int}>
+     */
+    protected $arrAllocations;
+
+    /**
      * Create a new MSPDI writer
      *
      * @param PhpProject $phpProject
@@ -45,6 +51,7 @@ class MSPDI implements WriterInterface
     public function __construct(PhpProject $phpProject)
     {
         $this->phpProject = $phpProject;
+        $this->arrAllocations = array();
     }
 
     /**
@@ -72,6 +79,15 @@ class MSPDI implements WriterInterface
         $xml->startElement('Resources');
         foreach ($this->phpProject->getAllResources() as $resource) {
             $this->writeResource($xml, $resource);
+        }
+        $xml->endElement();
+
+        // Assignments
+        $xml->startElement('Assignments');
+        if (count($this->arrAllocations) > 0) {
+            foreach ($this->arrAllocations as $allocation) {
+                $this->writeAssignment($xml, $allocation['id_task'], $allocation['id_res']);
+            }
         }
         $xml->endElement();
 
@@ -118,6 +134,32 @@ class MSPDI implements WriterInterface
             $xml->writeElement('Work', (string) $task->getDuration());
         }
         $xml->writeElement('PercentComplete', (string) (int) (($task->getProgress() ?? 0) * 100));
+
+        // Resources allocations
+        if ($task->getResourceCount() > 0) {
+            foreach ($task->getResources() as $resource) {
+                $allocation = array();
+                $allocation['id_res'] = $resource->getIndex();
+                $allocation['id_task'] = $task->getIndex();
+                $this->arrAllocations[] = $allocation;
+            }
+        }
+
+        $xml->endElement();
+    }
+
+    /**
+     * Write an assignment of a resource to a task
+     * @param XMLWriter $xml
+     * @param int $idTask
+     * @param int $idResource
+     */
+    protected function writeAssignment(XMLWriter $xml, int $idTask, int $idResource): void
+    {
+        $xml->startElement('Assignment');
+        $xml->writeElement('TaskUID', (string) $idTask);
+        $xml->writeElement('ResourceUID', (string) $idResource);
+        $xml->writeElement('Units', '1');
         $xml->endElement();
     }
 }

--- a/src/PhpProject/Writer/MSPDI.php
+++ b/src/PhpProject/Writer/MSPDI.php
@@ -23,6 +23,7 @@ namespace PhpOffice\PhpProject\Writer;
 use PhpOffice\PhpProject\PhpProject;
 use PhpOffice\PhpProject\Resource;
 use PhpOffice\PhpProject\Shared\XMLWriter;
+use PhpOffice\PhpProject\Task;
 
 /**
  * MSPDI (Microsoft Project Data Interchange) writer
@@ -60,6 +61,13 @@ class MSPDI implements WriterInterface
         $xml->startElement('Project');
         $xml->writeAttribute('xmlns', 'http://schemas.microsoft.com/project');
 
+        // Tasks
+        $xml->startElement('Tasks');
+        foreach ($this->phpProject->getAllTasks() as $task) {
+            $this->writeTask($xml, $task);
+        }
+        $xml->endElement();
+
         // Resources
         $xml->startElement('Resources');
         foreach ($this->phpProject->getAllResources() as $resource) {
@@ -88,6 +96,28 @@ class MSPDI implements WriterInterface
         $xml->startElement('Resource');
         $xml->writeElement('UID', (string) $resource->getIndex());
         $xml->writeElement('Name', $resource->getTitle());
+        $xml->endElement();
+    }
+
+    /**
+     * @param XMLWriter $xml
+     * @param Task $task
+     */
+    protected function writeTask(XMLWriter $xml, Task $task): void
+    {
+        $xml->startElement('Task');
+        $xml->writeElement('UID', (string) $task->getIndex());
+        $xml->writeElement('Name', $task->getName());
+        if ($task->getStartDate() !== null) {
+            $xml->writeElement('Start', date('Y-m-d\TH:i:s', $task->getStartDate()));
+        }
+        if ($task->getEndDate() !== null) {
+            $xml->writeElement('Finish', date('Y-m-d\TH:i:s', $task->getEndDate()));
+        }
+        if ($task->getDuration() !== null) {
+            $xml->writeElement('Work', (string) $task->getDuration());
+        }
+        $xml->writeElement('PercentComplete', (string) (int) (($task->getProgress() ?? 0) * 100));
         $xml->endElement();
     }
 }

--- a/src/PhpProject/Writer/MSPDI.php
+++ b/src/PhpProject/Writer/MSPDI.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Writer;
+
+use PhpOffice\PhpProject\PhpProject;
+use PhpOffice\PhpProject\Resource;
+use PhpOffice\PhpProject\Shared\XMLWriter;
+
+/**
+ * MSPDI (Microsoft Project Data Interchange) writer
+ */
+class MSPDI implements WriterInterface
+{
+    /**
+     * PHPProject object
+     *
+     * @var PhpProject
+     */
+    protected $phpProject;
+
+    /**
+     * Create a new MSPDI writer
+     *
+     * @param PhpProject $phpProject
+     */
+    public function __construct(PhpProject $phpProject)
+    {
+        $this->phpProject = $phpProject;
+    }
+
+    /**
+     * @param string $pFilename
+     * @throws \Exception
+     */
+    public function save(string $pFilename): void
+    {
+        // Create XML Object
+        $xml = new XMLWriter(XMLWriter::STORAGE_DISK);
+        $xml->startDocument('1.0', 'UTF-8');
+
+        // Project
+        $xml->startElement('Project');
+        $xml->writeAttribute('xmlns', 'http://schemas.microsoft.com/project');
+
+        // Resources
+        $xml->startElement('Resources');
+        foreach ($this->phpProject->getAllResources() as $resource) {
+            $this->writeResource($xml, $resource);
+        }
+        $xml->endElement();
+
+        // >Project
+        $xml->endElement();
+
+        // Writing XML Object in file
+        if (file_exists($pFilename) && !is_writable($pFilename)) {
+            throw new \Exception("Could not open file $pFilename for writing.");
+        }
+        $fileHandle = fopen($pFilename, 'wb+');
+        fwrite($fileHandle, $xml->getData());
+        fclose($fileHandle);
+    }
+
+    /**
+     * @param XMLWriter $xml
+     * @param Resource $resource
+     */
+    protected function writeResource(XMLWriter $xml, Resource $resource): void
+    {
+        $xml->startElement('Resource');
+        $xml->writeElement('UID', (string) $resource->getIndex());
+        $xml->writeElement('Name', $resource->getTitle());
+        $xml->endElement();
+    }
+}

--- a/tests/PhpProject/Tests/Writer/MSPDITest.php
+++ b/tests/PhpProject/Tests/Writer/MSPDITest.php
@@ -43,6 +43,7 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $oTask = $oPHPProject->createTask();
         $oTask->setName('Task1Test');
         $oTask->setStartDate('2014-08-07');
+        $oTask->setEndDate('2014-08-13');
         $oTask->setDuration('PT8H0M0S');
         $oTask->setProgress(0.5);
 
@@ -65,6 +66,7 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($oXMLDocument->elementExists($task, $fileOutput));
         $this->assertEquals('Task1Test', $oXMLDocument->getElement($task.'/*[local-name()="Name"]', $fileOutput)->nodeValue);
         $this->assertEquals('2014-08-07T00:00:00', $oXMLDocument->getElement($task.'/*[local-name()="Start"]', $fileOutput)->nodeValue);
+        $this->assertEquals('2014-08-13T00:00:00', $oXMLDocument->getElement($task.'/*[local-name()="Finish"]', $fileOutput)->nodeValue);
         $this->assertEquals('PT8H0M0S', $oXMLDocument->getElement($task.'/*[local-name()="Work"]', $fileOutput)->nodeValue);
         $this->assertEquals('50', $oXMLDocument->getElement($task.'/*[local-name()="PercentComplete"]', $fileOutput)->nodeValue);
     }

--- a/tests/PhpProject/Tests/Writer/MSPDITest.php
+++ b/tests/PhpProject/Tests/Writer/MSPDITest.php
@@ -40,6 +40,12 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $oResource = $oPHPProject->createResource();
         $oResource->setTitle('ResourceTest');
 
+        $oTask = $oPHPProject->createTask();
+        $oTask->setName('Task1Test');
+        $oTask->setStartDate('2014-08-07');
+        $oTask->setDuration('PT8H0M0S');
+        $oTask->setProgress(0.5);
+
         $xmlWriter = IOFactory::createWriter($oPHPProject, 'MSPDI');
         $xmlWriter->save($fileOutput);
 
@@ -53,6 +59,14 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($oXMLDocument->elementExists($resource, $fileOutput));
         $this->assertEquals('0', $oXMLDocument->getElement($resource.'/*[local-name()="UID"]', $fileOutput)->nodeValue);
         $this->assertEquals('ResourceTest', $oXMLDocument->getElement($resource.'/*[local-name()="Name"]', $fileOutput)->nodeValue);
+
+        // Task
+        $task = '/*[local-name()="Project"]/*[local-name()="Tasks"]/*[local-name()="Task"]';
+        $this->assertTrue($oXMLDocument->elementExists($task, $fileOutput));
+        $this->assertEquals('Task1Test', $oXMLDocument->getElement($task.'/*[local-name()="Name"]', $fileOutput)->nodeValue);
+        $this->assertEquals('2014-08-07T00:00:00', $oXMLDocument->getElement($task.'/*[local-name()="Start"]', $fileOutput)->nodeValue);
+        $this->assertEquals('PT8H0M0S', $oXMLDocument->getElement($task.'/*[local-name()="Work"]', $fileOutput)->nodeValue);
+        $this->assertEquals('50', $oXMLDocument->getElement($task.'/*[local-name()="PercentComplete"]', $fileOutput)->nodeValue);
     }
 
     public function testSaveException(): void

--- a/tests/PhpProject/Tests/Writer/MSPDITest.php
+++ b/tests/PhpProject/Tests/Writer/MSPDITest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Tests\Writer;
+
+use PhpOffice\PhpProject\IOFactory;
+use PhpOffice\PhpProject\PhpProject;
+use PhpOffice\PhpProject\Tests\XmlDocument;
+
+/**
+ * Test class for MSPDI writer
+ *
+ * @runTestsInSeparateProcesses
+ */
+class MSPDITest extends \PHPUnit\Framework\TestCase
+{
+    public function testSave(): void
+    {
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+
+        $oPHPProject = new PhpProject();
+
+        $oResource = $oPHPProject->createResource();
+        $oResource->setTitle('ResourceTest');
+
+        $xmlWriter = IOFactory::createWriter($oPHPProject, 'MSPDI');
+        $xmlWriter->save($fileOutput);
+
+        $oXMLDocument = new XmlDocument();
+
+        // Project
+        $this->assertTrue($oXMLDocument->elementExists('/*[local-name()="Project"]', $fileOutput));
+
+        // Resource
+        $resource = '/*[local-name()="Project"]/*[local-name()="Resources"]/*[local-name()="Resource"]';
+        $this->assertTrue($oXMLDocument->elementExists($resource, $fileOutput));
+        $this->assertEquals('0', $oXMLDocument->getElement($resource.'/*[local-name()="UID"]', $fileOutput)->nodeValue);
+        $this->assertEquals('ResourceTest', $oXMLDocument->getElement($resource.'/*[local-name()="Name"]', $fileOutput)->nodeValue);
+    }
+
+    public function testSaveException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Could not open file");
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+        file_put_contents($fileOutput, 'AA');
+        chmod($fileOutput, 0044);
+
+        $oPHPProject = new PhpProject();
+        $oResource = $oPHPProject->createResource();
+        $oResource->setTitle('ResourceTest');
+
+        $xmlWriter = IOFactory::createWriter($oPHPProject, 'MSPDI');
+        $xmlWriter->save($fileOutput);
+    }
+}

--- a/tests/PhpProject/Tests/Writer/MSPDITest.php
+++ b/tests/PhpProject/Tests/Writer/MSPDITest.php
@@ -46,6 +46,7 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $oTask->setEndDate('2014-08-13');
         $oTask->setDuration('PT8H0M0S');
         $oTask->setProgress(0.5);
+        $oTask->addResource($oResource);
 
         $xmlWriter = IOFactory::createWriter($oPHPProject, 'MSPDI');
         $xmlWriter->save($fileOutput);
@@ -69,6 +70,13 @@ class MSPDITest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2014-08-13T00:00:00', $oXMLDocument->getElement($task.'/*[local-name()="Finish"]', $fileOutput)->nodeValue);
         $this->assertEquals('PT8H0M0S', $oXMLDocument->getElement($task.'/*[local-name()="Work"]', $fileOutput)->nodeValue);
         $this->assertEquals('50', $oXMLDocument->getElement($task.'/*[local-name()="PercentComplete"]', $fileOutput)->nodeValue);
+
+        // Assignment
+        $assignment = '/*[local-name()="Project"]/*[local-name()="Assignments"]/*[local-name()="Assignment"]';
+        $this->assertTrue($oXMLDocument->elementExists($assignment, $fileOutput));
+        $this->assertEquals('0', $oXMLDocument->getElement($assignment.'/*[local-name()="TaskUID"]', $fileOutput)->nodeValue);
+        $this->assertEquals('0', $oXMLDocument->getElement($assignment.'/*[local-name()="ResourceUID"]', $fileOutput)->nodeValue);
+        $this->assertEquals('1', $oXMLDocument->getElement($assignment.'/*[local-name()="Units"]', $fileOutput)->nodeValue);
     }
 
     public function testSaveException(): void


### PR DESCRIPTION
Implements a writer for the MSPDI XML format. See #19.

Work in progress, added step by step:
- [x] Resources
- [x] Tasks
- [x] Assignments
- [x] Docs + CHANGELOG
