### PR TITLE
Add HTML writer with frappe-gantt chart (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
+- Added HTML writer rendering the project as a Gantt chart (frappe-gantt) for `.html` files (tasks with subtasks and progress) - @slayerfx GH-56
 - Added MSPDI (Microsoft Project Data Interchange) writer for `.xml` files (resources, tasks, and assignments) - @slayerfx GH-55
 - Added MSPDI (Microsoft Project Data Interchange) reader for `.xml` files (resources, tasks, and assignments) - @slayerfx GH-54
 - Added Gnome Planner writer for `.planner` files (resources, tasks with subtasks, and allocations) - @slayerfx GH-53

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ PhpProject is an open source project licensed under the terms of [LGPL version 3
 - Set file meta data (author, title, description, etc)
 - Add resources from scratch or from existing one
 - Add tasks from scratch or from existing one
-- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner), MSPDI (.xml)
+- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner), MSPDI (.xml), HTML (.html)
 - ... and lots of other things!
 
 ## File formats
@@ -19,14 +19,14 @@ Below are the supported features for each file formats.
 
 ### Writers
 
-| Features                  |            | MPX | GAN | Planner | MSPDI |
-|---------------------------|------------|-----|-----|---------|-------|
-| **Document Properties**   | Standard   |     |     |         |       |
-|                           | Custom     |     |     |         |       |
-| **Document Informations** |            |     |     |         |       |
-| **Project**               | Task       | ✓   | ✓   | ✓       | ✓     |
-|                           | Resource   | ✓   | ✓   | ✓       | ✓     |
-|                           | Allocation | ✓   | ✓   | ✓       | ✓     |
+| Features                  |            | MPX | GAN | Planner | MSPDI | HTML |
+|---------------------------|------------|-----|-----|---------|-------|------|
+| **Document Properties**   | Standard   |     |     |         |       |      |
+|                           | Custom     |     |     |         |       |      |
+| **Document Informations** |            |     |     |         |       |      |
+| **Project**               | Task       | ✓   | ✓   | ✓       | ✓     | ✓    |
+|                           | Resource   | ✓   | ✓   | ✓       | ✓     |      |
+|                           | Allocation | ✓   | ✓   | ✓       | ✓     |      |
 
 ### Readers
 

--- a/src/PhpProject/Writer/HTML.php
+++ b/src/PhpProject/Writer/HTML.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Writer;
+
+use PhpOffice\PhpProject\PhpProject;
+use PhpOffice\PhpProject\Task;
+
+/**
+ * HTML writer (Gantt chart rendered with frappe-gantt)
+ */
+class HTML implements WriterInterface
+{
+    /**
+     * PHPProject object
+     *
+     * @var PhpProject
+     */
+    protected $phpProject;
+
+    /**
+     * Create a new HTML writer
+     *
+     * @param PhpProject $phpProject
+     */
+    public function __construct(PhpProject $phpProject)
+    {
+        $this->phpProject = $phpProject;
+    }
+
+    /**
+     * @param string $pFilename
+     * @throws \Exception
+     */
+    public function save(string $pFilename): void
+    {
+        // Tasks (frappe-gantt JS objects)
+        $tasks = '';
+        foreach ($this->phpProject->getAllTasks() as $task) {
+            $tasks .= $this->writeTask($task);
+        }
+
+        // Full HTML page : header + tasks + footer
+        $content = $this->writeHeader() . $tasks . $this->writeFooter();
+
+        // Writing the HTML page in file
+        if (file_exists($pFilename) && !is_writable($pFilename)) {
+            throw new \Exception("Could not open file $pFilename for writing.");
+        }
+        $fileHandle = fopen($pFilename, 'wb+');
+        fwrite($fileHandle, $content);
+        fclose($fileHandle);
+    }
+
+    /**
+     * Generate the HTML header : page skeleton, frappe-gantt includes and the
+     * opening of the tasks array.
+     *
+     * @return string
+     */
+    protected function writeHeader(): string
+    {
+        return <<<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PhpProject</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.css">
+</head>
+<body>
+    <div id="gantt"></div>
+    <script src="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.umd.js"></script>
+    <script>
+        let tasks = [
+
+HTML;
+    }
+
+    /**
+     * Generate the JS object for one task (frappe-gantt format).
+     *
+     * @param Task $task
+     * @return string
+     */
+    protected function writeTask(Task $task): string
+    {
+        $data = array(
+            'id' => (string) $task->getIndex(),
+            'name' => $task->getName(),
+        );
+        if ($task->getStartDate() !== null) {
+            $data['start'] = date('Y-m-d', $task->getStartDate());
+        }
+        if ($task->getEndDate() !== null) {
+            $data['end'] = date('Y-m-d', $task->getEndDate());
+        }
+        $data['progress'] = (int) (($task->getProgress() ?? 0) * 100);
+
+        $line = '            ' . (string) json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . ",\n";
+
+        // Sub-tasks (recursive)
+        foreach ($task->getTasks() as $taskChild) {
+            $line .= $this->writeTask($taskChild);
+        }
+
+        return $line;
+    }
+
+    /**
+     * Generate the HTML footer : close the tasks array, instantiate the Gantt
+     * chart and close the page.
+     *
+     * @return string
+     */
+    protected function writeFooter(): string
+    {
+        return <<<'HTML'
+        ];
+        let gantt = new Gantt("#gantt", tasks);
+    </script>
+</body>
+</html>
+HTML;
+    }
+}

--- a/src/PhpProject/Writer/HTML.php
+++ b/src/PhpProject/Writer/HTML.php
@@ -84,10 +84,10 @@ class HTML implements WriterInterface
     <meta charset="UTF-8">
     <title>PhpProject</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.css">
+    <script src="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.umd.js"></script>
 </head>
 <body>
     <div id="gantt"></div>
-    <script src="https://cdn.jsdelivr.net/npm/frappe-gantt/dist/frappe-gantt.umd.js"></script>
     <script>
         let tasks = [
 

--- a/tests/PhpProject/Tests/Writer/HTMLTest.php
+++ b/tests/PhpProject/Tests/Writer/HTMLTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Tests\Writer;
+
+use PhpOffice\PhpProject\IOFactory;
+use PhpOffice\PhpProject\PhpProject;
+
+/**
+ * Test class for HTML writer
+ *
+ * @runTestsInSeparateProcesses
+ */
+class HTMLTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSave(): void
+    {
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+
+        $oPHPProject = new PhpProject();
+
+        $oTask = $oPHPProject->createTask();
+        $oTask->setName('Task1Test');
+        $oTask->setStartDate('2014-08-07');
+        $oTask->setEndDate('2014-08-13');
+        $oTask->setProgress(0.5);
+
+        $oSubTask = $oTask->createTask();
+        $oSubTask->setName('SubTaskTest');
+
+        $writer = IOFactory::createWriter($oPHPProject, 'HTML');
+        $writer->save($fileOutput);
+
+        $content = (string) file_get_contents($fileOutput);
+
+        // frappe-gantt includes and container
+        $this->assertStringContainsString('frappe-gantt.css', $content);
+        $this->assertStringContainsString('frappe-gantt.umd.js', $content);
+        $this->assertStringContainsString('<div id="gantt"></div>', $content);
+        $this->assertStringContainsString('new Gantt("#gantt", tasks)', $content);
+
+        // Task
+        $this->assertStringContainsString('"name":"Task1Test"', $content);
+        $this->assertStringContainsString('"start":"2014-08-07"', $content);
+        $this->assertStringContainsString('"end":"2014-08-13"', $content);
+        $this->assertStringContainsString('"progress":50', $content);
+
+        // Sub-task (heritage)
+        $this->assertStringContainsString('"name":"SubTaskTest"', $content);
+    }
+
+    public function testSaveException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Could not open file");
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+        file_put_contents($fileOutput, 'AA');
+        chmod($fileOutput, 0044);
+
+        $oPHPProject = new PhpProject();
+        $oTask = $oPHPProject->createTask();
+        $oTask->setName('Task1Test');
+
+        $writer = IOFactory::createWriter($oPHPProject, 'HTML');
+        $writer->save($fileOutput);
+    }
+}


### PR DESCRIPTION
Implements an HTML writer that exports the project as a Gantt chart, rendered with the frappe-gantt JS library. See #15.

Work in progress, added step by step:
- [x] HTML header (frappe-gantt includes via CDN)
- [x] Tasks with subtasks and progress
- [x] Tests
- [x] Docs + CHANGELOG
