### PR TITLE
Add ProjectLibre writer (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 
 ### Miscellaneous
+- Added ProjectLibre writer for `.pod` files (writes an embedded MSPDI part) - @slayerfx GH-58
 - Added ProjectLibre reader for `.pod` files (reads the embedded MSPDI part) - @slayerfx GH-57
 - Added HTML writer rendering the project as a Gantt chart (frappe-gantt) for `.html` files (tasks with subtasks and progress) - @slayerfx GH-56
 - Added MSPDI (Microsoft Project Data Interchange) writer for `.xml` files (resources, tasks, and assignments) - @slayerfx GH-55

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ PhpProject is an open source project licensed under the terms of [LGPL version 3
 - Set file meta data (author, title, description, etc)
 - Add resources from scratch or from existing one
 - Add tasks from scratch or from existing one
-- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner), MSPDI (.xml), HTML (.html)
+- Output to different file formats: MSProjectExchange (.mpx), GanttProject (.gan), Gnome Planner (.planner), MSPDI (.xml), HTML (.html), ProjectLibre (.pod)
 - ... and lots of other things!
 
 ## File formats
@@ -19,14 +19,14 @@ Below are the supported features for each file formats.
 
 ### Writers
 
-| Features                  |            | MPX | GAN | Planner | MSPDI | HTML |
-|---------------------------|------------|-----|-----|---------|-------|------|
-| **Document Properties**   | Standard   |     |     |         |       |      |
-|                           | Custom     |     |     |         |       |      |
-| **Document Informations** |            |     |     |         |       |      |
-| **Project**               | Task       | ✓   | ✓   | ✓       | ✓     | ✓    |
-|                           | Resource   | ✓   | ✓   | ✓       | ✓     |      |
-|                           | Allocation | ✓   | ✓   | ✓       | ✓     |      |
+| Features                  |            | MPX | GAN | Planner | MSPDI | HTML | ProjectLibre |
+|---------------------------|------------|-----|-----|---------|-------|------|--------------|
+| **Document Properties**   | Standard   |     |     |         |       |      |              |
+|                           | Custom     |     |     |         |       |      |              |
+| **Document Informations** |            |     |     |         |       |      |              |
+| **Project**               | Task       | ✓   | ✓   | ✓       | ✓     | ✓    | ✓            |
+|                           | Resource   | ✓   | ✓   | ✓       | ✓     |      | ✓            |
+|                           | Allocation | ✓   | ✓   | ✓       | ✓     |      | ✓            |
 
 ### Readers
 

--- a/src/PhpProject/Writer/ProjectLibre.php
+++ b/src/PhpProject/Writer/ProjectLibre.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Writer;
+
+use PhpOffice\PhpProject\PhpProject;
+use PhpOffice\PhpProject\Reader\ProjectLibre as ProjectLibreReader;
+
+/**
+ * ProjectLibre writer
+ *
+ * A ProjectLibre `.pod` file is made of serialized Java data, a separator, then
+ * an MSPDI file. This writer outputs a minimal `.pod`: the Java stream signature,
+ * the separator, then an MSPDI file produced by the MSPDI writer. The file can be
+ * read back by the ProjectLibre reader.
+ */
+class ProjectLibre implements WriterInterface
+{
+    /**
+     * Java serialization stream signature placed at the beginning of a `.pod` file
+     */
+    const JAVA_PREAMBLE = "\xAC\xED\x00\x05";
+
+    /**
+     * PHPProject object
+     *
+     * @var PhpProject
+     */
+    protected $phpProject;
+
+    /**
+     * Create a new ProjectLibre writer
+     *
+     * @param PhpProject $phpProject
+     */
+    public function __construct(PhpProject $phpProject)
+    {
+        $this->phpProject = $phpProject;
+    }
+
+    /**
+     * @param string $pFilename
+     * @throws \Exception
+     */
+    public function save(string $pFilename): void
+    {
+        if (file_exists($pFilename) && !is_writable($pFilename)) {
+            throw new \Exception("Could not open file $pFilename for writing.");
+        }
+
+        // The MSPDI writer writes to a file, so we let it produce the MSPDI part
+        // in a temporary file before reading it back.
+        $tempFile = (string) tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+        (new MSPDI($this->phpProject))->save($tempFile);
+        $mspdi = (string) file_get_contents($tempFile);
+        unlink($tempFile);
+
+        // Assemble the minimal .pod: preamble + separator + MSPDI.
+        $content = self::JAVA_PREAMBLE.ProjectLibreReader::MSPDI_SEPARATOR.$mspdi;
+
+        $fileHandle = fopen($pFilename, 'wb+');
+        fwrite($fileHandle, $content);
+        fclose($fileHandle);
+    }
+}

--- a/tests/PhpProject/Tests/Writer/ProjectLibreTest.php
+++ b/tests/PhpProject/Tests/Writer/ProjectLibreTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of PHPProject - A pure PHP library for reading and writing
+ * project management files.
+ *
+ * PHPProject is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPProject/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPProject
+ * @copyright   2009-2014 PHPProject contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpProject\Tests\Writer;
+
+use PhpOffice\PhpProject\IOFactory;
+use PhpOffice\PhpProject\PhpProject;
+use PhpOffice\PhpProject\Reader\ProjectLibre as ProjectLibreReader;
+use PhpOffice\PhpProject\Writer\ProjectLibre as ProjectLibreWriter;
+
+/**
+ * Test class for ProjectLibre writer
+ *
+ * @runTestsInSeparateProcesses
+ */
+class ProjectLibreTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSave(): void
+    {
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+
+        $oPHPProject = new PhpProject();
+
+        $oResource = $oPHPProject->createResource();
+        $oResource->setTitle('ResourceTest');
+
+        $oTask = $oPHPProject->createTask();
+        $oTask->setName('Task1Test');
+        $oTask->addResource($oResource);
+
+        $writer = IOFactory::createWriter($oPHPProject, 'ProjectLibre');
+        $writer->save($fileOutput);
+
+        // The file is a minimal `.pod`: Java preamble, separator, then MSPDI.
+        $content = (string) file_get_contents($fileOutput);
+        $this->assertStringStartsWith(ProjectLibreWriter::JAVA_PREAMBLE, $content);
+        $this->assertStringContainsString(ProjectLibreReader::MSPDI_SEPARATOR, $content);
+
+        // Round-trip: the ProjectLibre reader must read the data back.
+        $oRead = (new ProjectLibreReader())->load($fileOutput);
+
+        $resources = $oRead->getAllResources();
+        $this->assertCount(1, $resources);
+        $this->assertEquals('ResourceTest', $resources[0]->getTitle());
+
+        $tasks = $oRead->getAllTasks();
+        $this->assertCount(1, $tasks);
+        $this->assertEquals('Task1Test', $tasks[0]->getName());
+    }
+
+    public function testSaveException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Could not open file');
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+        file_put_contents($fileOutput, 'AA');
+        chmod($fileOutput, 0044);
+
+        $oPHPProject = new PhpProject();
+        $oResource = $oPHPProject->createResource();
+        $oResource->setTitle('ResourceTest');
+
+        $writer = IOFactory::createWriter($oPHPProject, 'ProjectLibre');
+        $writer->save($fileOutput);
+    }
+}


### PR DESCRIPTION
Adds a writer for the ProjectLibre format (.pod). See #23.

 - [x] Writer (delegates to MSPDI)
 - [x] Docs + CHANGELOG
 - [x] Tests 