### PR TITLE
Fix flaky date tests comparing two separate time() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Broadened `XMLReader::getElement` and `getElements` `$contextNode` parameter to `?\DOMNode` (was `?\DOMElement`) - @slayerfx GH-35
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
+- Fixed flaky date tests (`Task`, `DocumentInformations`, `DocumentProperties`) comparing two separate `time()` calls, which failed whenever the second changed between them; the argument-less setters are now asserted against a time range - @slayerfx GH-60
 
 ### Miscellaneous
 - Added ProjectLibre writer for `.pod` files (writes an embedded MSPDI part) - @slayerfx GH-58

--- a/tests/PhpProject/Tests/DocumentInformationsTest.php
+++ b/tests/PhpProject/Tests/DocumentInformationsTest.php
@@ -37,8 +37,11 @@ class DocumentInformationsTest extends \PHPUnit\Framework\TestCase
         $value = time();
         
         $object = new DocumentInformations();
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setEndDate());
-        $this->assertEquals($value, $object->getEndDate());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getEndDate());
+        $this->assertLessThanOrEqual($after, $object->getEndDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setEndDate((string) $value));
         $this->assertEquals($value, $object->getEndDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setEndDate('2014-08-05 19:30:00'));
@@ -50,8 +53,11 @@ class DocumentInformationsTest extends \PHPUnit\Framework\TestCase
         $value = time();
         
         $object = new DocumentInformations();
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setStartDate());
-        $this->assertEquals($value, $object->getStartDate());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getStartDate());
+        $this->assertLessThanOrEqual($after, $object->getStartDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setStartDate((string) $value));
         $this->assertEquals($value, $object->getStartDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentInformations', $object->setStartDate('2014-08-05 19:30:00'));

--- a/tests/PhpProject/Tests/DocumentPropertiesTest.php
+++ b/tests/PhpProject/Tests/DocumentPropertiesTest.php
@@ -188,8 +188,11 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $value = time();
     
         $object = new DocumentProperties();
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCreated());
-        $this->assertEquals($value, $object->getCreated());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getCreated());
+        $this->assertLessThanOrEqual($after, $object->getCreated());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCreated((string) $value));
         $this->assertEquals($value, $object->getCreated());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setCreated('2014-08-05 19:30:00'));
@@ -246,8 +249,11 @@ class DocumentPropertiesTest extends \PHPUnit\Framework\TestCase
         $value = time();
     
         $object = new DocumentProperties();
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setModified());
-        $this->assertEquals($value, $object->getModified());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getModified());
+        $this->assertLessThanOrEqual($after, $object->getModified());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setModified((string) $value));
         $this->assertEquals($value, $object->getModified());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\DocumentProperties', $object->setModified('2014-08-05 19:30:00'));

--- a/tests/PhpProject/Tests/TaskTest.php
+++ b/tests/PhpProject/Tests/TaskTest.php
@@ -55,10 +55,13 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $object = new Task();
         
         $value = time();
-    
+
         $this->assertEquals('', $object->getEndDate());
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setEndDate());
-        $this->assertEquals($value, $object->getEndDate());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getEndDate());
+        $this->assertLessThanOrEqual($after, $object->getEndDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setEndDate($value));
         $this->assertEquals($value, $object->getEndDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setEndDate((string)$value));
@@ -109,10 +112,13 @@ class TaskTest extends \PHPUnit\Framework\TestCase
         $object = new Task();
         
         $value = time();
-    
+
         $this->assertEquals('', $object->getStartDate());
+        $before = time();
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setStartDate());
-        $this->assertEquals($value, $object->getStartDate());
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $object->getStartDate());
+        $this->assertLessThanOrEqual($after, $object->getStartDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setStartDate($value));
         $this->assertEquals($value, $object->getStartDate());
         $this->assertInstanceOf('PhpOffice\\PhpProject\\Task', $object->setStartDate((string)$value));


### PR DESCRIPTION
The argument-less date setters call `time()` internally, while the tests captured their own `time()` beforehand and compared both with `assertEquals` failing whenever the second changed between the two calls (turned the CI red on #56). The date is now asserted against a `[before, after]` range instead.

- [x] `TaskTest`, `DocumentInformationsTest`, `DocumentPropertiesTest` (6 tests)
- [x] CHANGELOG (GH-60)
