### PR TITLE
Fix Gnome Planner reader storing percent-complete as a raw 0-100 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Restricted `XMLReader::getElement` return type to `DOMElement|null` using `instanceof` check - @slayerfx GH-35
 - Fixed date setters (`Task`, `DocumentInformations`, `DocumentProperties`) storing `strtotime()` `false` for unparseable date strings; now stored as `null` to match the typed `?int` getters (revealed by the samples job) - @slayerfx GH-45
 - Fixed flaky date tests (`Task`, `DocumentInformations`, `DocumentProperties`) comparing two separate `time()` calls, which failed whenever the second changed between them; the argument-less setters are now asserted against a time range - @slayerfx GH-60
+- Fixed `Reader/GnomePlanner` storing `percent-complete` as a raw 0-100 value, while `Task::setProgress()` expects a 0..1 fraction and clamps anything above 1; progress is now divided by 100, as in `Reader/MSPDI` - @slayerfx GH-61
 
 ### Miscellaneous
 - Added ProjectLibre writer for `.pod` files (writes an embedded MSPDI part) - @slayerfx GH-58

--- a/src/PhpProject/Reader/GnomePlanner.php
+++ b/src/PhpProject/Reader/GnomePlanner.php
@@ -169,7 +169,7 @@ class GnomePlanner implements ReaderInterface
             $task->setDuration($domNode->getAttribute('work'));
         }
         if ($domNode->hasAttribute('percent-complete')) {
-            $task->setProgress($domNode->getAttribute('percent-complete'));
+            $task->setProgress((float) $domNode->getAttribute('percent-complete') / 100);
         }
 
         // SubNodes

--- a/tests/PhpProject/Tests/Reader/GnomePlannerTest.php
+++ b/tests/PhpProject/Tests/Reader/GnomePlannerTest.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpProject\Tests\Reader;
 
+use PhpOffice\PhpProject\IOFactory;
+use PhpOffice\PhpProject\PhpProject;
 use PhpOffice\PhpProject\Reader\GnomePlanner;
 
 /**
@@ -98,6 +100,27 @@ class GnomePlannerTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $taskResources);
         $this->assertEquals('Sue Maute', $taskResources[0]->getTitle());
         $this->assertEquals('Kurt Maute', $taskResources[1]->getTitle());
+    }
+
+    public function testLoadProgressRoundTrip(): void
+    {
+        $fileOutput = tempnam(sys_get_temp_dir(), 'PHPPROJECT');
+
+        $phpProject = new PhpProject();
+        $task = $phpProject->createTask();
+        $task->setName('ProgressTest');
+        $task->setProgress(0.5);
+
+        IOFactory::createWriter($phpProject, 'GnomePlanner')->save($fileOutput);
+
+        $object = new GnomePlanner();
+        $return = $object->load($fileOutput);
+
+        $tasks = $return->getAllTasks();
+        $this->assertCount(1, $tasks);
+        $this->assertEquals(0.5, $tasks[0]->getProgress());
+
+        unlink($fileOutput);
     }
 
     public function testLoadException(): void


### PR DESCRIPTION
`Task::setProgress()` expects a 0..1 fraction and clamps anything above 1, so `percent-complete="50"` was stored as `1.0` (100%). The reader now divides by 100, as `Reader/MSPDI` already does. Found while writing the writer for #22, the writer side was already correct.

- [x] Round-trip test (write 0.5 → read back 0.5)
- [x] CHANGELOG (GH-61)
